### PR TITLE
MergeDedupConsumer: Use the full timestamp for deduplication.

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/MergeDedupConsumer.java
+++ b/src/main/org/epics/archiverappliance/retrieval/MergeDedupConsumer.java
@@ -35,7 +35,7 @@ class MergeDedupConsumer implements EventStreamConsumer, AutoCloseable {
 	int skippedEvents = 0;
 	int comparedEvents = 0;
 	OutputStream os = null;
-	long epochSecondsOfLastEventInPreviousStream = 0;
+	private Timestamp timestampOfLastEvent;
 	boolean amIDeduping = false;
 	boolean haveIpushedTheFirstEvent = false;
 	Event firstEvent = null;
@@ -129,26 +129,25 @@ class MergeDedupConsumer implements EventStreamConsumer, AutoCloseable {
 							totalEvents++;
 							mimeresponse.consumeEvent(e);
 							totalEvents++;
-							epochSecondsOfLastEventInPreviousStream = e.getEpochSeconds();
+							timestampOfLastEvent = e.getEventTimeStamp();
 							continue;
 						}
 					}
 					
 					if(amIDeduping) {
 						comparedEvents++;
-						long currentEpochSeconds = e.getEpochSeconds(); 
-						if(currentEpochSeconds <= epochSecondsOfLastEventInPreviousStream) {
+						if(!e.getEventTimeStamp().after(timestampOfLastEvent)) {
 							skippedEvents++;
 							continue;
 						} else {
 							amIDeduping = false;
 							mimeresponse.consumeEvent(e);
-							epochSecondsOfLastEventInPreviousStream = e.getEpochSeconds();
+							timestampOfLastEvent = e.getEventTimeStamp();
 							totalEvents++;
 						}
 					} else {
 						mimeresponse.consumeEvent(e);
-						epochSecondsOfLastEventInPreviousStream = e.getEpochSeconds();
+						timestampOfLastEvent = e.getEventTimeStamp();
 						totalEvents++;
 					}
 				} catch(InvalidProtocolBufferException|PBParseException ex) { 
@@ -185,7 +184,7 @@ class MergeDedupConsumer implements EventStreamConsumer, AutoCloseable {
 		totalEvents = 0;
 		skippedEvents = 0;
 		comparedEvents = 0;
-		epochSecondsOfLastEventInPreviousStream = 0;
+		timestampOfLastEvent = new Timestamp(Long.MIN_VALUE);
 		amIDeduping = false;
 		firstEvent = null;
 		haveIpushedTheFirstEvent = false;


### PR DESCRIPTION
Please see the screenshot below; this is a display of the last few seconds of data. The point where the gap starts is where the STS data ends and where data from the engine buffers begins. So, a small initial part of the engine buffers is not returned in the retrieval.

The cause is the MergeDedupConsumer which performs deduplication based on whole seconds only, and it skips some data that it should not. I have fixed this issue by making it compare Timestamps instead.

![missing-data1](https://cloud.githubusercontent.com/assets/2626481/10884848/86f33f54-817a-11e5-9daa-0af5477e5092.jpg)
