### PR TITLE
Many bug fixes and other improvements, generic data sources

### DIFF
--- a/src/main/edu/stanford/slac/archiverappliance/PB/utils/LineEscaper.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/utils/LineEscaper.java
@@ -23,40 +23,52 @@ import org.apache.log4j.Logger;
 public class LineEscaper {
 	public static final byte ESCAPE_CHAR = 0x1B;
 	public static final byte ESCAPE_ESCAPE_CHAR = 0x01;
-	public static final byte[] ESCAPE_CHAR_SEQUENCE = { ESCAPE_CHAR, ESCAPE_ESCAPE_CHAR} ;
 	public static final byte NEWLINE_CHAR = 0x0A;
 	public static final byte NEWLINE_ESCAPE_CHAR = 0x02;
 	public static final String NEWLINE_CHAR_STR = "\n";
-	public static final byte[] NEWLINE_CHAR_SEQUENCE = { ESCAPE_CHAR, NEWLINE_ESCAPE_CHAR} ;
 	public static final byte CARRIAGERETURN_CHAR = 0x0D;
 	public static final byte CARRIAGERETURN_ESCAPE_CHAR = 0x03;
-	public static final byte[] CARRIAGERETURN_CHAR_SEQUENCE = { ESCAPE_CHAR, CARRIAGERETURN_ESCAPE_CHAR} ;
 	private static Logger logger = Logger.getLogger(LineEscaper.class.getName());
-	
-
-	public static void escapeNewLines(byte[] input, OutputStream os) throws IOException {
-		if(input == null) return;
-		for(byte b : input) {
-			switch(b) {
-			case ESCAPE_CHAR: os.write(ESCAPE_CHAR_SEQUENCE);break;
-			case NEWLINE_CHAR: os.write(NEWLINE_CHAR_SEQUENCE);break;
-			case CARRIAGERETURN_CHAR: os.write(CARRIAGERETURN_CHAR_SEQUENCE);break;
-			default: os.write(b);break;
-			}
-		}
-	}
 	
 	public static byte[] escapeNewLines(byte[] input) {
 		if(input == null) return null;
-		try {
-			ByteArrayOutputStream bos = new ByteArrayOutputStream(input.length*2);
-			escapeNewLines(input, bos);
-			bos.close();
-			return bos.toByteArray();
-		} catch(IOException ex) {
-			logger.error("Exception escaping newlines in buffer", ex);
-			return null;
+		
+		int output_len = input.length;
+		
+		for (byte b : input) {
+				switch(b) {
+				case ESCAPE_CHAR:
+				case NEWLINE_CHAR:
+				case CARRIAGERETURN_CHAR:
+						output_len++;
+						break;
+				}
 		}
+		
+		byte[] output = new byte[output_len];
+		int o = 0;
+		
+		for (byte b : input) {
+				switch(b) {
+				case ESCAPE_CHAR:
+						output[o++] = ESCAPE_CHAR;
+						output[o++] = ESCAPE_ESCAPE_CHAR;
+						break;
+				case NEWLINE_CHAR:
+						output[o++] = ESCAPE_CHAR;
+						output[o++] = NEWLINE_ESCAPE_CHAR;
+						break;
+				case CARRIAGERETURN_CHAR:
+						output[o++] = ESCAPE_CHAR;
+						output[o++] = CARRIAGERETURN_ESCAPE_CHAR;
+						break;
+				default:
+						output[o++] = b;
+						break;
+				}
+		}
+		
+		return output;
 	}
 
 	public static byte[] unescapeNewLines(byte[] input) {

--- a/src/main/edu/stanford/slac/archiverappliance/PlainPB/AppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PlainPB/AppendDataStateData.java
@@ -330,12 +330,12 @@ public class AppendDataStateData {
 		try(ByteChannel destChannel = Files.newByteChannel(pvPath, StandardOpenOption.APPEND); ReadableByteChannel srcChannel = bulkStream.getByteChannel(context)) {
 			logger.debug("ETL bulk appends for pv " + pvName);
 			ByteBuffer buf = ByteBuffer.allocate(1024*1024);
-			int bytesRead = srcChannel.read(buf);
-			while(bytesRead > 0) {
+			while (srcChannel.read(buf) > 0) {
 				buf.flip();
-				destChannel.write(buf);
+				do {
+					destChannel.write(buf);
+				} while (buf.remaining() > 0);
 				buf.clear();
-				bytesRead = srcChannel.read(buf);
 			}
 		}
 

--- a/src/main/edu/stanford/slac/archiverappliance/PlainPB/AppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PlainPB/AppendDataStateData.java
@@ -121,7 +121,8 @@ public class AppendDataStateData {
 			logger.error("Exception appending data for PV " + pvName, t);
 			throw new IOException(t);
 		} finally {
-			if(this.os != null) { try { this.os.close(); this.os = null; } catch(Throwable t) { logger.error("Exception closing os", t); } }
+			if(this.os != null) { try { this.os.close(); } catch(Throwable t) { logger.error("Exception closing os", t); } }
+			this.os = null;
 			try { stream.close(); } catch (Throwable t) {} 
 		}
 	}

--- a/src/main/edu/stanford/slac/archiverappliance/PlainPB/AppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PlainPB/AppendDataStateData.java
@@ -122,8 +122,7 @@ public class AppendDataStateData {
 			
 			return eventsAppended;
 		} catch(Throwable t) {
-			logger.error("Exception appending data for PV " + pvName, t);
-			throw new IOException(t);
+			throw (t instanceof IOException) ? (IOException)t : new IOException(t);
 		} finally {
 			closeOutputStream(false);
 			try { stream.close(); } catch (Throwable t) {} 
@@ -262,14 +261,14 @@ public class AppendDataStateData {
 			info = new PBFileInfo(pvPath);
 		} catch (PBFileInfo.MissingHeaderException ex) {
 			// handle incomplete header - truncate the file and write the header
-			logger.warn("Restarting PB file " + pvPath + " due to incomplete header");
+			logger.info("Restarting PB file " + pvPath + " due to incomplete header");
 			createNewFileAndWriteAHeader(pvName, pvPath, stream, true);
 			return;
 		}
 		
 		if (info.getPositionOfDataEnd() != info.getFileSize()) {
 			// Fix corruption at the end.
-			logger.warn("Truncating incomplete data in PB file " + pvPath);
+			logger.info("Truncating incomplete data in PB file " + pvPath);
 			try (SeekableByteChannel channel = Files.newByteChannel(pvPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
 				channel.truncate(info.getPositionOfDataEnd());
 			}
@@ -363,7 +362,7 @@ public class AppendDataStateData {
 			try {
 				the_os.close();
 			} catch (IOException ex) {
-				logger.error("Exception closing os", ex);
+				logger.info("Error closing output: " + ex.getMessage());
 				if (allow_throw) {
 					throw ex;
 				}

--- a/src/main/org/epics/archiverappliance/common/BPLDefaultHandler.java
+++ b/src/main/org/epics/archiverappliance/common/BPLDefaultHandler.java
@@ -1,0 +1,12 @@
+package org.epics.archiverappliance.common;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.epics.archiverappliance.config.ConfigService;
+
+public interface BPLDefaultHandler {
+	public boolean handleRequest(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException;
+}

--- a/src/main/org/epics/archiverappliance/config/ChannelArchiver/EngineConfigParser.java
+++ b/src/main/org/epics/archiverappliance/config/ChannelArchiver/EngineConfigParser.java
@@ -54,9 +54,11 @@ public class EngineConfigParser extends DefaultHandler {
 	StringWriter getThresholdBuf = null;
 	StringWriter nameBuf = null;
 	StringWriter periodBuf = null;
+	StringWriter policyBuf = null;
 	String name = null;
 	String period = null;
 	boolean monitor = true;
+	String policy = null;
 	// According to the channel archiver manual, this defaults to 20 seconds.
 	int getThreshold = 20;
 	
@@ -72,6 +74,8 @@ public class EngineConfigParser extends DefaultHandler {
 			monitor = true;
 		} else if (inChannel && qName.equals("scan")) {
 			monitor = false;
+		} else if (inChannel && qName.equals("policy")) {
+			policyBuf = new StringWriter();
 		} else if(qName.equals("get_threshold")) {
 			getThresholdBuf = new StringWriter();
 		}
@@ -82,16 +86,20 @@ public class EngineConfigParser extends DefaultHandler {
 		if(qName.equals("channel")) {
 			inChannel = false;
 			float samplingperiod = Float.parseFloat(period);
-			pvConfigs.add(new PVConfig(name, samplingperiod, monitor));
+			pvConfigs.add(new PVConfig(name, samplingperiod, monitor, policy));
 			name = null;
 			period = null;
 			monitor = false;
+			policy = null;
 		} else if (inChannel && qName.equals("name") && nameBuf != null) {
 			name = nameBuf.toString();
 			nameBuf = null;
 		} else if (inChannel && qName.equals("period") && periodBuf != null) {
 			period = periodBuf.toString();
 			periodBuf = null;
+		} else if (inChannel && qName.equals("policy") && policyBuf != null) {
+			policy = policyBuf.toString();
+			policyBuf = null;
 		} else if(qName.equals("get_threshold") && getThresholdBuf != null) {
 			getThreshold = Integer.parseInt(getThresholdBuf.toString());
 			getThresholdBuf = null;
@@ -104,6 +112,8 @@ public class EngineConfigParser extends DefaultHandler {
 			nameBuf.append(new String(ch, start, length));
 		} else if(inChannel && periodBuf != null) {
 			periodBuf.append(new String(ch, start, length));
+		} else if(inChannel && policyBuf != null) {
+			policyBuf.append(new String(ch, start, length));
 		} else if(getThresholdBuf != null) {
 			getThresholdBuf.append(new String(ch, start, length));
 		}
@@ -130,7 +140,7 @@ public class EngineConfigParser extends DefaultHandler {
 	"                         max_repeat_count|disconnect)*,\n" + 
 	"                         group+)>\n" + 
 	"<!ELEMENT group (name,channel+)>\n" + 
-	"<!ELEMENT channel (name,period,(scan|monitor),disable?)>\n" + 
+	"<!ELEMENT channel (name,period,(scan|monitor),policy?,disable?)>\n" + 
 	"<!ELEMENT write_period (#PCDATA)><!-- int seconds -->\n" + 
 	"<!ELEMENT get_threshold (#PCDATA)><!-- int seconds -->\n" + 
 	"<!ELEMENT file_size (#PCDATA)><!-- MB -->\n" + 
@@ -142,6 +152,7 @@ public class EngineConfigParser extends DefaultHandler {
 	"<!ELEMENT period (#PCDATA)><!-- double seconds -->\n" + 
 	"<!ELEMENT scan EMPTY>\n" + 
 	"<!ELEMENT monitor EMPTY>\n" + 
+	"<!ELEMENT policy (#PCDATA)>\n" + 
 	"<!ELEMENT disable EMPTY>\n";
 
 	

--- a/src/main/org/epics/archiverappliance/config/ChannelArchiver/PVConfig.java
+++ b/src/main/org/epics/archiverappliance/config/ChannelArchiver/PVConfig.java
@@ -17,12 +17,14 @@ public class PVConfig {
 	private String PVName;
 	private float samplingPeriod;
 	private boolean monitor;
+	private String policy;
 	
-	public PVConfig(String pVName, float period, boolean monitor) {
+	public PVConfig(String pVName, float period, boolean monitor, String policy) {
 		super();
 		PVName = pVName;
 		this.samplingPeriod = period;
 		this.monitor = monitor;
+		this.policy = policy;
 	}
 
 	public String getPVName() {
@@ -37,8 +39,16 @@ public class PVConfig {
 		return monitor;
 	}
 
+	public String getPolicy() {
+		return policy;
+	}
+
 	@Override
 	public String toString() {
-		return "PV: " + PVName + " is being " + (monitor ? "monitored" : "scanned") + " with period " + samplingPeriod + "(s)";
+		String result = "PV: " + PVName + " is being " + (monitor ? "monitored" : "scanned") + " with period " + samplingPeriod + "(s)";
+		if (policy != null) {
+			result = result + " and policy " + policy;
+		}
+		return result;
 	}
 }

--- a/src/main/org/epics/archiverappliance/config/ConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigService.java
@@ -196,6 +196,12 @@ public interface ConfigService {
 	public Iterable<String> getAllPVs();
 	
 	/**
+	 * Get a set of pending archive requests.
+	 * This is meant to be read only, and may be just an unmodifiableSet on top of a live data structure.
+	 */
+	public Set<String> getArchiveRequestsSet ();
+	
+	/**
 	 * Given a PV, get us the appliance that is responsible for archiving it.
 	 * Note that this may be null as the assignment of PV's to appliances can take some time. 
 	 * @param pvName

--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -978,7 +978,12 @@ public class DefaultConfigService implements ConfigService {
 		}
 		return allPVs;
 	}
-
+	
+	@Override
+	public Set<String> getArchiveRequestsSet () {
+		return Collections.unmodifiableSet(archivePVRequests.keySet());
+	}
+	
 	@Override
 	public ApplianceInfo getApplianceForPV(String pvName) {
 		ApplianceInfo applianceInfo = pv2appliancemapping.get(pvName);

--- a/src/main/org/epics/archiverappliance/config/persistence/MySQLPersistence.java
+++ b/src/main/org/epics/archiverappliance/config/persistence/MySQLPersistence.java
@@ -209,7 +209,7 @@ public class MySQLPersistence implements ConfigPersistence {
 				stmt.setString(3, jsonStr);
 				int rowsChanged = stmt.executeUpdate();
 				if(rowsChanged != 1) {
-					logger.warn(rowsChanged + " rows changed when updating key  " + key + " in " + msg);
+					logger.debug(rowsChanged + " rows changed when updating key  " + key + " in " + msg);
 				} else {
 					logger.debug("Successfully updated value for key " + key + " in " + msg);
 				}
@@ -231,7 +231,7 @@ public class MySQLPersistence implements ConfigPersistence {
 				stmt.setString(3, value);
 				int rowsChanged = stmt.executeUpdate();
 				if(rowsChanged != 1) {
-					logger.warn(rowsChanged + " rows changed when updating key  " + key + " in " + msg);
+					logger.debug(rowsChanged + " rows changed when updating key  " + key + " in " + msg);
 				} else {
 					logger.debug("Successfully updated value for key " + key + " in " + msg);
 				}
@@ -248,7 +248,7 @@ public class MySQLPersistence implements ConfigPersistence {
 				stmt.setString(1, key);
 				int rowsChanged = stmt.executeUpdate();
 				if(rowsChanged != 1) {
-					logger.warn(rowsChanged + " rows changed when removing key  " + key + " in " + msg);
+					logger.debug(rowsChanged + " rows changed when removing key  " + key + " in " + msg);
 				} else {
 					logger.debug("Successfully removed key " + key + " in " + msg);
 				}

--- a/src/main/org/epics/archiverappliance/engine/bpl/PausePVsOnShutdown.java
+++ b/src/main/org/epics/archiverappliance/engine/bpl/PausePVsOnShutdown.java
@@ -26,17 +26,8 @@ public class PausePVsOnShutdown implements BPLAction {
 	@Override
 	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
 		configlogger.info("Pausing PVs on potential shutdown");
-		EngineContext engineRuntime = configService.getEngineContext();
-		int pvCount = 0;
-		for(String pvName : engineRuntime.getChannelList().keySet()) {
-			try { 
-				ArchiveEngine.pauseArchivingPV(pvName, configService);
-				pvCount++;
-			} catch(Exception ex) {
-				configlogger.error("Exception pausing PV " + pvName, ex);
-			}
-		}
-
+		int pvCount = ArchiveEngine.pauseAllPvs(configlogger, configService);
+		
 		HashMap<String, Object> infoValues = new HashMap<String, Object>();
 		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
 		try(PrintWriter out = resp.getWriter()) {

--- a/src/main/org/epics/archiverappliance/engine/generic/DummyGenericEngineDefinition.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/DummyGenericEngineDefinition.java
@@ -1,0 +1,247 @@
+package org.epics.archiverappliance.engine.generic;
+
+import java.lang.reflect.Constructor;
+import java.io.PrintWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.config.MetaInfo;
+import org.epics.archiverappliance.config.TypeSystem;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.engine.generic.GenericEngine;
+import org.epics.archiverappliance.engine.generic.GenericEngineDefinition;
+import org.epics.archiverappliance.engine.generic.GenericEngineRequester;
+import org.epics.archiverappliance.engine.generic.GenericChannelParams;
+import org.epics.archiverappliance.engine.generic.GenericChannel;
+import org.epics.archiverappliance.engine.generic.GenericChannelRequester;
+import org.epics.archiverappliance.engine.generic.GenericMetaGet;
+import org.epics.archiverappliance.engine.generic.GenericMetaGetRequester;
+import org.epics.archiverappliance.engine.generic.ScopedLogger;
+import org.epics.archiverappliance.data.DBRTimeEvent;
+import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
+import gov.aps.jca.dbr.DBR_TIME_Double;
+import gov.aps.jca.dbr.TimeStamp;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.json.simple.JSONValue;
+
+public class DummyGenericEngineDefinition implements GenericEngineDefinition
+{
+	@Override
+	public String getName()
+	{
+		return "dummy_generic";
+	}
+
+	@Override
+	public GenericEngine createEngine(GenericEngineRequester requester) throws Exception
+	{
+		return new DummyGenericEngine(requester);
+	}
+}
+
+class DummyGenericEngine implements GenericEngine
+{
+	public DummyGenericEngine(GenericEngineRequester requester)
+	{
+		m_requester = requester;
+	}
+
+	@Override
+	public void destroy()
+	{
+	}
+	
+	@Override
+	public GenericChannel addChannel(String channelName, GenericChannelParams params, GenericChannelRequester requester) throws Exception
+	{
+		DummyGenericChannel channel = new DummyGenericChannel(m_requester.getTypeSystem(), channelName, params, requester);
+		channel.complete();
+		return channel;
+	}
+
+	@Override
+	public GenericMetaGet addMetaGet(String channelName, String metadatafields[], GenericMetaGetRequester requester) throws Exception
+	{
+		return new DummyGenericMetaGet(channelName, requester);
+	}
+	
+	@Override
+	public boolean handleHttpRequest(HttpServletRequest req, HttpServletResponse resp) throws IOException
+	{
+		if (!req.getPathInfo().equals("/dummyGenericEngine")) {
+			return false;
+		}
+		
+		HashMap<String, Object> infoValues = new HashMap<String, Object>();
+		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+		try (PrintWriter out = resp.getWriter()) {
+			infoValues.put("status", "ok");
+			infoValues.put("desc", "Dummy request is working.");
+			out.println(JSONValue.toJSONString(infoValues));
+		}
+		
+		return true;
+	}
+
+	public final GenericEngineRequester m_requester;
+}
+
+class DummyGenericChannel implements GenericChannel
+{
+	private static final double PERIOD = 30.0;
+	private static final double AMPLITUDE = 10.0;
+	
+	public DummyGenericChannel(TypeSystem type_system, String channelName, GenericChannelParams params, GenericChannelRequester requester) throws Exception
+	{
+		if (params.dbrType != ArchDBRTypes.DBR_SCALAR_DOUBLE) {
+			throw new Exception("Invalid dbrType");
+		}
+		
+		m_channel_name = channelName;
+		m_params = params;
+		m_requester = requester;
+		m_logger = requester.getLogger();
+		m_semaphore = new Semaphore(0);
+		m_thread = new Thread() { public void run() { DummyGenericChannel.this.thread_func(); } };
+		m_constructor = type_system.getJCADBRConstructor(params.dbrType);
+
+		m_thread.start();
+	}
+	
+	public void complete()
+	{
+		m_requester.initSampleBuffer(1.0 / m_params.samplingPeriod);
+	}
+	
+	@Override
+	public void destroy()
+	{
+		m_semaphore.release();
+		try {
+			m_thread.join();
+		} catch (InterruptedException ex) {}
+	}
+	
+	public void thread_func()
+	{
+		m_logger.info("Thread started");
+		
+		int counter = 0;
+		boolean connected = false;
+		
+		while (true) {
+			// Wait some time.
+			long waitTime_ms = (long)(1000.0 * Math.max(0.0, Math.min(3600.0, m_params.samplingPeriod)));
+			try {
+				if (m_semaphore.tryAcquire(waitTime_ms, TimeUnit.MILLISECONDS)) {
+					break;
+				}
+			} catch (InterruptedException ex) {
+				return;
+			}
+			
+			// Simulate some connection and disconnection.
+			if (counter > 0) {
+				counter--;
+			} else {
+				counter = 9;
+				connected = !connected;
+				m_requester.reportConnected(connected);
+			}
+			
+			// Get a JCA timestamp for the current time.
+			DateTime dt = new DateTime(DateTimeZone.UTC);
+			long ms = dt.getMillis();
+			TimeStamp ts = new TimeStamp((ms / 1000) - TimeUtils.EPICS_EPOCH_2_JAVA_EPOCH_OFFSET, (ms % 1000) * 1000000);
+			
+			// Make up a value.
+			double value = AMPLITUDE * Math.sin(ms * ((2.0 * Math.PI) / (1000.0 * PERIOD)));
+			
+			m_logger.debug(String.format("Sample %s %s", dt.toString(), value));
+			
+			// Create the DBR.
+			DBR_TIME_Double dbr = new DBR_TIME_Double(new double[]{value});
+			dbr.setSeverity(0);
+			dbr.setStatus(0);
+			dbr.setTimeStamp(ts);
+			
+			// Create the DBRTimeEvent from the DBR.
+			DBRTimeEvent sample;
+			try {
+				sample = m_constructor.newInstance(dbr);
+			} catch (Exception ex) {
+				m_logger.error("newInstance threw exception");
+				continue;
+			}
+			
+			m_requester.addSample(sample);
+		}
+
+		m_logger.info("Thread stopping");
+	}
+
+	public final String m_channel_name;
+	public final GenericChannelParams m_params;
+	public final GenericChannelRequester m_requester;
+	public final ScopedLogger m_logger;
+	public final Semaphore m_semaphore;
+	public volatile Thread m_thread;
+	public final Constructor<? extends DBRTimeEvent> m_constructor;
+}
+
+class DummyGenericMetaGet implements GenericMetaGet
+{
+	private static final double METAGET_TIME = 2.0;
+	
+	public DummyGenericMetaGet(String channelName, GenericMetaGetRequester requester)
+	{
+		m_requester = requester;
+		m_logger = requester.getLogger();
+		m_semaphore = new Semaphore(0);
+		m_thread = new Thread() { public void run() { DummyGenericMetaGet.this.thread_func(); } };
+		
+		m_thread.start();
+	}
+	
+	@Override
+	public void destroy()
+	{
+		m_semaphore.release();
+		try {
+			m_thread.join();
+		} catch (InterruptedException ex) {}
+	}
+	
+	private void thread_func()
+	{
+		m_logger.info("Thread started");
+		
+		try {
+			if (m_semaphore.tryAcquire((long)(METAGET_TIME * 1000.0), TimeUnit.MILLISECONDS)) {
+				return;
+			}
+		} catch (InterruptedException ex) {
+			return;
+		}
+		
+		m_logger.info("Simulating completed MetaGet");
+		
+		MetaInfo meta = new MetaInfo();
+		meta.setArchDBRTypes(ArchDBRTypes.DBR_SCALAR_DOUBLE);
+		meta.setEventCount(1);
+		
+		m_requester.metaGetCompleted(meta);
+		
+		m_logger.info("Thread stopping");
+	}
+	
+	public final GenericMetaGetRequester m_requester;
+	public final ScopedLogger m_logger;
+	public final Semaphore m_semaphore;
+	public final Thread m_thread;
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericChannel.java
@@ -1,0 +1,6 @@
+package org.epics.archiverappliance.engine.generic;
+
+public interface GenericChannel
+{
+	void destroy();
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericChannelParams.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericChannelParams.java
@@ -1,0 +1,18 @@
+package org.epics.archiverappliance.engine.generic;
+
+import org.epics.archiverappliance.mgmt.policy.PolicyConfig.SamplingMethod;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+
+public class GenericChannelParams
+{
+	public GenericChannelParams(float samplingPeriod, SamplingMethod mode, ArchDBRTypes dbrType)
+	{
+		this.samplingPeriod = samplingPeriod;
+		this.mode = mode;
+		this.dbrType = dbrType;
+	}
+	
+	public final float samplingPeriod;
+	public final SamplingMethod mode;
+	public final ArchDBRTypes dbrType;
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericChannelRequester.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericChannelRequester.java
@@ -1,0 +1,35 @@
+package org.epics.archiverappliance.engine.generic;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.epics.archiverappliance.data.DBRTimeEvent;
+import org.epics.archiverappliance.engine.generic.ScopedLogger;
+
+public interface GenericChannelRequester
+{
+    ScopedLogger getLogger();
+
+    void initSampleBuffer(double expectedFrequency);
+
+    boolean addSample(DBRTimeEvent timeevent);
+
+    void reportConnected(boolean connected);
+    
+    ConcurrentHashMap<String, String> getMetadataMap();
+    
+    class BulkStoreException extends Exception
+    {
+        public BulkStoreException(String msg) { super(msg); }
+        public BulkStoreException(String msg, Throwable th) { super(msg, th); }
+    }
+    
+    BulkStore startBulkStore(int buffer_size) throws BulkStoreException;
+    
+    public interface BulkStore
+    {
+        void addSample(DBRTimeEvent timeevent);
+        void complete();
+    }
+    
+    void logTrouble(String message);
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericEngine.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericEngine.java
@@ -1,0 +1,24 @@
+package org.epics.archiverappliance.engine.generic;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.epics.archiverappliance.engine.generic.GenericChannel;
+import org.epics.archiverappliance.engine.generic.GenericChannelParams;
+import org.epics.archiverappliance.engine.generic.GenericChannelRequester;
+import org.epics.archiverappliance.engine.generic.GenericMetaGet;
+import org.epics.archiverappliance.engine.generic.GenericMetaGetRequester;
+
+public interface GenericEngine
+{
+	void destroy();
+	
+	GenericChannel addChannel(String channelName, GenericChannelParams params, GenericChannelRequester requester) throws Exception;
+	
+	GenericMetaGet addMetaGet(String channelName, String metadatafields[], GenericMetaGetRequester requester) throws Exception;
+	
+	default boolean handleHttpRequest(HttpServletRequest req, HttpServletResponse resp) throws IOException
+	{
+		return false;
+	}
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericEngineDefinition.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericEngineDefinition.java
@@ -1,0 +1,11 @@
+package org.epics.archiverappliance.engine.generic;
+
+import org.epics.archiverappliance.engine.generic.GenericEngine;
+import org.epics.archiverappliance.engine.generic.GenericEngineRequester;
+
+public interface GenericEngineDefinition
+{
+	String getName();
+	
+	GenericEngine createEngine(GenericEngineRequester requester) throws Exception;
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericEngineMediator.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericEngineMediator.java
@@ -1,0 +1,807 @@
+package org.epics.archiverappliance.engine.generic;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.RejectedExecutionException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.sql.Timestamp;
+import org.apache.log4j.Logger;
+import gov.aps.jca.configuration.Configuration;
+import gov.aps.jca.configuration.DefaultConfigurationBuilder;
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.Writer;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.data.DBRTimeEvent;
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.common.BasicContext;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.config.MetaInfo;
+import org.epics.archiverappliance.config.TypeSystem;
+import org.epics.archiverappliance.engine.writer.WriterRunnable;
+import org.epics.archiverappliance.engine.epics.JCAConfigGen;
+import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
+import org.epics.archiverappliance.engine.model.SampleBuffer;
+import org.epics.archiverappliance.engine.model.ThrottledLogger;
+import org.epics.archiverappliance.engine.model.LogLevel;
+import org.epics.archiverappliance.engine.model.EngineWritable;
+import org.epics.archiverappliance.engine.metadata.MetaCompletedListener;
+import org.epics.archiverappliance.engine.pv.PVMetrics;
+import org.epics.archiverappliance.engine.pv.EngineContext;
+import org.epics.archiverappliance.engine.generic.GenericEngine;
+import org.epics.archiverappliance.engine.generic.GenericEngineDefinition;
+import org.epics.archiverappliance.engine.generic.GenericEngineRequester;
+import org.epics.archiverappliance.engine.generic.GenericChannel;
+import org.epics.archiverappliance.engine.generic.GenericChannelParams;
+import org.epics.archiverappliance.engine.generic.GenericChannelRequester;
+import org.epics.archiverappliance.engine.generic.GenericMetaGet;
+import org.epics.archiverappliance.engine.generic.GenericMetaGetRequester;
+import org.epics.archiverappliance.engine.generic.ScopedLogger;
+import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
+import org.epics.archiverappliance.mgmt.policy.PolicyConfig.SamplingMethod;
+
+public class GenericEngineMediator
+{
+	private static final Logger logger = Logger.getLogger("GenericEngine");
+	
+	public GenericEngineMediator(GenericEngineDefinition engine_def, ConfigService config_service) throws Exception
+	{
+		m_engine_def = engine_def;
+		m_config_service = config_service;
+		m_logger = new ScopedLogger(ScopedLogger.parentRoot(logger), engine_def.getName());
+		m_trouble_logger = new ThrottledLogger(LogLevel.error, 60);
+		m_channel_logger = new ScopedLogger(ScopedLogger.parentScope(m_logger), "channel");
+		m_metaget_logger = new ScopedLogger(ScopedLogger.parentScope(m_logger), "metaget");
+		m_channels = new HashMap<String, MediatorChannel>();
+		m_metagets = new HashMap<String, MediatorMetaGet>();
+		
+		m_bulk_flush_executor_threads = Integer.parseInt(getProperty("NumBulkFlushThreads", "4"));
+		if (m_bulk_flush_executor_threads <= 0) {
+			throw new Exception("NumBulkFlushThreads is out of range");
+		}
+	}
+	
+	public void complete() throws Exception
+	{
+		m_engine = m_engine_def.createEngine(m_this_requester);
+		
+		m_logger.info("Engine created");
+	}
+	
+	public synchronized void destroy()
+	{
+		if (m_destroyed) {
+			return;
+		}
+		
+		for (MediatorChannel med_channel : m_channels.values()) {
+			med_channel.destroy();
+		}
+		
+		for (MediatorMetaGet med_metaget : m_metagets.values()) {
+			med_metaget.destroy();
+		}
+		
+		m_engine.destroy();
+		
+		if (m_bulk_flush_executor != null) {
+			m_bulk_flush_executor.shutdown();
+		}
+		
+		m_destroyed = true;
+		
+		m_logger.info("Engine destroyed");
+	}
+	
+	public synchronized void addChannel(String channelName, String fullChannelName, float samplingPeriod, SamplingMethod mode, int secondsToBuffer, Writer writer, ArchDBRTypes dbrType, Timestamp last_archived_timestamp) throws Exception
+	{
+		m_logger.info(String.format("addChannel %s", channelName));
+		
+		this.destroyed_check();
+		
+		if (m_channels.containsKey(channelName)) {
+			throw new Exception(String.format("Channel '%s' already exists", channelName));
+		}
+		
+		GenericChannelParams params = new GenericChannelParams(samplingPeriod, mode, dbrType);
+		
+		add_channel_common(channelName, fullChannelName, writer, last_archived_timestamp, params);
+	}
+	
+	public synchronized void changeChannelParameters(String channelName, float samplingPeriod, SamplingMethod mode, Writer writer) throws Exception
+	{
+		m_logger.info(String.format("changeChannelParameters %s", channelName));
+		
+		this.destroyed_check();
+		
+		MediatorChannel old_med_channel = m_channels.remove(channelName);
+		if (old_med_channel == null) {
+			throw new Exception(String.format("Channel '%s' does not exist", channelName));
+		}
+		
+		old_med_channel.destroy();
+		
+		GenericChannelParams params = new GenericChannelParams(samplingPeriod, mode, old_med_channel.m_type);
+		
+		add_channel_common(channelName, old_med_channel.m_full_channel_name, writer, old_med_channel.m_last_archived_timestamp, params);
+	}
+	
+	public synchronized void destroyChannel(String channelName) throws Exception
+	{
+		m_logger.info(String.format("destroyChannel %s", channelName));
+		
+		this.destroyed_check();
+		
+		MediatorChannel med_channel = m_channels.remove(channelName);
+		
+		if (med_channel != null) {
+			med_channel.destroy();
+		}
+	}
+	
+	public synchronized boolean haveChannel(String channelName) throws Exception
+	{
+		m_logger.debug(String.format("haveChannel %s", channelName));
+		
+		this.destroyed_check();
+		
+		return m_channels.containsKey(channelName);
+	}
+	
+	public synchronized void getMetaInfo(String channelName, String metadatafields[], MetaCompletedListener listener) throws Exception
+	{
+		m_logger.debug(String.format("getMetaInfo %s", channelName));
+		
+		this.destroyed_check();
+		
+		if (m_metagets.containsKey(channelName)) {
+			throw new Exception(String.format("MetaGet already in progress for channel '%s'", channelName));
+		}
+		
+		MediatorMetaGet med_metaget = new MediatorMetaGet(this, channelName, listener);
+		
+		GenericMetaGet metaget = m_engine.addMetaGet(channelName, metadatafields, med_metaget);
+		
+		med_metaget.complete(metaget);
+		
+		m_metagets.put(channelName, med_metaget);
+	}
+	
+	public synchronized boolean abortMetaInfo(String channelName) throws Exception
+	{
+		m_logger.info(String.format("abortMetaInfo %s", channelName));
+		
+		this.destroyed_check();
+		
+		MediatorMetaGet med_metaget = m_metagets.remove(channelName);
+		if (med_metaget == null) {
+			return false;
+		}
+		
+		med_metaget.destroy();
+		
+		return true;
+	}
+	
+	public synchronized PVMetrics getChannelMetrics(String channelName) throws Exception
+	{
+		m_logger.debug(String.format("getChannelMetrics %s", channelName));
+		
+		this.destroyed_check();
+		
+		MediatorChannel med_channel = m_channels.get(channelName);
+		if (med_channel == null) {
+			return null;
+		}
+		
+		return med_channel.m_metrics;
+	}
+	
+	public synchronized HashMap<String, String> getChannelMetadata(String channelName) throws Exception
+	{
+		m_logger.debug(String.format("getChannelMetadata %s", channelName));
+		
+		this.destroyed_check();
+		
+		MediatorChannel med_channel = m_channels.get(channelName);
+		if (med_channel == null) {
+			return null;
+		}
+		
+		return new HashMap(med_channel.m_metadata);
+	}
+	
+	public synchronized ArrayList<String> getChannelNames() throws Exception
+	{
+		m_logger.debug("getChannelNames");
+		
+		this.destroyed_check();
+		
+		ArrayList<String> result = new ArrayList<String>();
+		result.addAll(m_channels.keySet());
+		return result;
+	}
+	
+	private void destroyed_check() throws Exception
+	{
+		if (m_destroyed) {
+			throw new Exception("Engine destroyed");
+		}
+	}
+	
+	private String getProperty(String name, String default_value)
+	{
+		String full_name = String.format("org.epics.archiverappliance.engine.%s.%s", m_engine_def.getName(), name);
+		return m_config_service.getInstallationProperties().getProperty(full_name, default_value);
+	}
+	
+	private GenericEngineRequester m_this_requester = new GenericEngineRequester() {
+		@Override
+		public ScopedLogger getLogger()
+		{
+			return m_logger;
+		}
+		
+		@Override
+		public TypeSystem getTypeSystem()
+		{
+			return m_config_service.getArchiverTypeSystem();
+		}
+		
+		@Override
+		public Configuration getJcaConfiguration() throws Exception
+		{
+			ByteArrayInputStream bis = JCAConfigGen.generateJCAConfig(m_config_service);
+			DefaultConfigurationBuilder configBuilder = new DefaultConfigurationBuilder();
+			Configuration configuration = configBuilder.build(bis);
+			return configuration;
+		}
+		
+		@Override
+		public ScheduledThreadPoolExecutor getScheduler()
+		{
+			return m_config_service.getEngineContext().getScheduler();
+		}
+		
+		@Override
+		public ConfigService getConfigService()
+		{
+			return m_config_service;
+		}
+		
+		@Override
+		public String getProperty(String name, String default_value)
+		{
+			return GenericEngineMediator.this.getProperty(name, default_value);
+		}
+	};
+	
+	private void add_channel_common(String channelName, String fullChannelName, Writer writer, Timestamp last_archived_timestamp, GenericChannelParams params) throws Exception
+	{
+		WriterRunnable writer_runnable = m_config_service.getEngineContext().getWriteThead();
+		
+		MediatorChannel med_channel = new MediatorChannel(this, channelName, fullChannelName, writer, last_archived_timestamp, writer_runnable, params);
+		
+		GenericChannel channel;
+		try {
+			channel = m_engine.addChannel(channelName, params, med_channel);
+		} catch (Exception ex) {
+			med_channel.destroy();
+			throw ex;
+		}
+		
+		med_channel.complete(channel);
+		
+		m_channels.put(channelName, med_channel);
+	}
+	
+	protected synchronized ExecutorService get_bulk_flush_executor()
+	{
+		if (m_bulk_flush_executor == null && !m_destroyed) {
+			m_bulk_flush_executor = Executors.newFixedThreadPool(m_bulk_flush_executor_threads);
+		}
+		return m_bulk_flush_executor;
+	}
+	
+	protected final GenericEngineDefinition m_engine_def;
+	protected final ConfigService m_config_service;
+	protected final ScopedLogger m_logger;
+	protected final ThrottledLogger m_trouble_logger;
+	protected final ScopedLogger m_channel_logger;
+	protected final ScopedLogger m_metaget_logger;
+	private boolean m_destroyed;
+	private final HashMap<String, MediatorChannel> m_channels;
+	protected final HashMap<String, MediatorMetaGet> m_metagets;
+	protected final int m_bulk_flush_executor_threads;
+	protected GenericEngine m_engine;
+	protected ExecutorService m_bulk_flush_executor;
+}
+
+class MediatorChannel implements GenericChannelRequester, EngineWritable
+{
+	protected MediatorChannel(GenericEngineMediator mediator, String channelName, String fullChannelName, Writer writer,
+		Timestamp last_archived_timestamp, WriterRunnable writer_runnable, GenericChannelParams params)
+	{
+		m_mediator = mediator;
+		m_full_channel_name = fullChannelName;
+		m_writer = writer;
+		m_type = params.dbrType;
+		m_last_archived_timestamp = last_archived_timestamp;
+		m_writer_runnable = writer_runnable;
+		
+		m_logger = new ScopedLogger(ScopedLogger.parentScope(mediator.m_channel_logger), channelName);
+		
+		m_metrics = new PVMetrics(m_full_channel_name, null, System.currentTimeMillis() / 1000, null);
+		m_metrics.setMonitor(true);
+	}
+	
+	protected void complete(GenericChannel channel)
+	{
+		m_channel = channel;
+		
+		m_logger.info("Channel created");
+	}
+	
+	protected void destroy()
+	{
+		if (m_channel != null) {
+			m_channel.destroy();
+		}
+		
+		synchronized (m_data_lock) {
+			m_destroyed = true;
+			
+			if (m_buffer != null) {
+				m_writer_runnable.removeChannel(m_full_channel_name);
+			}
+		}
+		
+		if (m_channel != null) {
+			m_logger.info("Channel destroyed");
+		}
+	}
+	
+	@Override
+	public ScopedLogger getLogger()
+	{
+		return m_logger;
+	}
+	
+	@Override
+	public void initSampleBuffer(double expectedFrequency)
+	{
+		// This can be called from GenericEngine.addChannel(), between MediatorChannel() and complete().
+		// Se we need to do the buffer cleanup in destroy() if addChannel fails.
+		
+		synchronized (m_data_lock) {
+			if (m_destroyed) {
+				return;
+			}
+			
+			if (m_buffer == null) {
+				m_buffer = new SampleBuffer(m_full_channel_name, calc_buffer_capacity(expectedFrequency), m_type, m_metrics);
+				
+				m_writer_runnable.addChannel(this);
+				
+				m_metrics.setSamplingPeriod(1.0 / expectedFrequency);
+			}
+		}
+	}
+	
+	@Override
+	public boolean addSample(DBRTimeEvent timeevent)
+	{
+		synchronized (m_data_lock) {
+			if (m_destroyed) {
+				return false;
+			}
+			
+			m_metrics.setElementCount(timeevent.getSampleValue().getElementCount());
+			m_metrics.setSecondsOfLastEvent(System.currentTimeMillis() / 1000);
+
+			try { 
+				if (isfutureorpastOrSame(timeevent)) {
+					if (!isSameTimeStamp(timeevent)) {
+						m_metrics.addTimestampWrongEventCount(timeevent.getEventTimeStamp());
+					}
+					return false;
+				}
+			} catch (IllegalArgumentException ex) {
+				m_metrics.addTimestampWrongEventCount(timeevent.getEventTimeStamp());
+				return false;
+			}
+
+			m_metrics.setLastEventFromIOCTimeStamp(timeevent.getEventTimeStamp());
+			//this.lastDBRTimeEvent = timeevent;
+			m_last_archived_timestamp = timeevent.getEventTimeStamp();
+
+			boolean incrementEventCounts = false;
+			if (m_buffer != null) {
+				incrementEventCounts = m_buffer.add(timeevent);
+			}
+			
+			if (incrementEventCounts) {
+				m_metrics.addEventCounts();
+				m_metrics.addStorageSize(timeevent);
+			}
+
+			//if (SampleBuffer.isInErrorState()) {
+			//	need_write_error_sample = true;
+			//}
+		}
+		
+		return true;
+	}
+	
+	@Override
+	public void reportConnected(boolean connected)
+	{
+		synchronized (m_data_lock) {
+			boolean old_connected = m_connected;
+			m_connected = connected;
+			
+			if (connected != old_connected) {
+				long now = System.currentTimeMillis() / 1000;
+				if (connected) {
+					if (m_first_connected == 0) {
+						m_first_connected = now;
+					} else {
+						m_last_reconnected = now;
+						m_regain_count++;
+					}
+				} else {
+					m_last_disconnected = now;
+				}
+			}
+			
+			m_metrics.setConnected(connected);
+			m_metrics.setArchving(connected);
+			m_metrics.setConnectionFirstEstablishedEpochSeconds(m_first_connected);
+			m_metrics.setConnectionLastRestablishedEpochSeconds(m_last_reconnected);
+			m_metrics.setConnectionLastLostEpochSeconds(m_last_disconnected);
+			m_metrics.setConnectionLossRegainCount(m_regain_count);
+			m_metrics.setLastConnectionEventState(old_connected);
+		}
+	}
+	
+	@Override
+	public ConcurrentHashMap<String, String> getMetadataMap()
+	{
+		return m_metadata;
+	}
+	
+	@Override
+	public GenericChannelRequester.BulkStore startBulkStore(int buffer_size) throws GenericChannelRequester.BulkStoreException
+	{
+		synchronized (m_data_lock) {
+			if (m_destroyed) {
+				throw new GenericChannelRequester.BulkStoreException("Channel has been destroyed.");
+			}
+			
+			if (m_buffer != null) {
+				throw new GenericChannelRequester.BulkStoreException("Cannot bulk store if sample buffer was initialized.");
+			}
+			
+			if (m_bulk_store != null) {
+				throw new GenericChannelRequester.BulkStoreException("A bulk store is already in progress.");
+			}
+			
+			m_bulk_store = new BulkStoreImpl(buffer_size);
+			
+			return m_bulk_store;
+		}
+	}
+	
+	@Override
+	public void logTrouble(String message)
+	{
+		m_mediator.m_trouble_logger.log(m_logger.buildMessage(message));
+	}
+	
+	@Override
+	public String getName()
+	{
+		return m_full_channel_name;
+	}
+	
+	@Override
+	public SampleBuffer getSampleBuffer()
+	{
+		return m_buffer;
+	}
+	
+	@Override
+	public Writer getWriter()
+	{
+		return m_writer;
+	}
+	
+	@Override
+	public void setlastRotateLogsEpochSeconds(long lastRotateLogsEpochSecond)
+	{
+		synchronized (m_data_lock) {
+			m_metrics.setLastRotateLogsEpochSeconds(lastRotateLogsEpochSecond);
+		}
+	}
+	
+	private boolean isfutureorpastOrSame(final DBRTimeEvent timeevent)
+	{
+		Timestamp currentEventTimeStamp = timeevent.getEventTimeStamp();
+
+		if(currentEventTimeStamp.before(PAST_CUTOFF_TIMESTAMP)) {
+			logTrouble("timestamp is too far in the past " + TimeUtils.convertToHumanReadableString(currentEventTimeStamp));
+			return true;
+		}
+
+		Timestamp futureCutOffTimeStamp = TimeUtils.convertFromEpochSeconds(TimeUtils.getCurrentEpochSeconds() + FUTURE_CUTOFF_SECONDS, 0);
+		if(currentEventTimeStamp.after(futureCutOffTimeStamp)) {
+			logTrouble("timestamp " + TimeUtils.convertToHumanReadableString(currentEventTimeStamp) + " is after the future cutoff " + TimeUtils.convertToHumanReadableString(futureCutOffTimeStamp));
+			return true;
+		}
+
+		if (m_last_archived_timestamp != null) {
+			Timestamp lastEventTimeStamp = m_last_archived_timestamp;
+			if(currentEventTimeStamp.before(lastEventTimeStamp)) {
+				logTrouble("timestamp " + TimeUtils.convertToHumanReadableString(currentEventTimeStamp) + " is before the previous event's timestamp " + TimeUtils.convertToHumanReadableString(lastEventTimeStamp));
+				return true;
+			} else if(currentEventTimeStamp.equals(lastEventTimeStamp)){
+				logTrouble("timestamp " + TimeUtils.convertToHumanReadableString(currentEventTimeStamp) + " is the same as  the previous event's timestamp " + TimeUtils.convertToHumanReadableString(lastEventTimeStamp));
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	private boolean isSameTimeStamp(final DBRTimeEvent timeevent)
+	{
+		return (m_last_archived_timestamp != null && timeevent.getEventTimeStamp().equals(m_last_archived_timestamp));
+	}
+	
+	private int calc_buffer_capacity(double expectedFrequency)
+	{
+		EngineContext engineContext = m_mediator.m_config_service.getEngineContext();
+		double write_period = engineContext.getWritePeriod();
+		int buffer_capacity = ((int) Math.round(Math.max((write_period*expectedFrequency)*engineContext.getSampleBufferCapacityAdjustment(), 1.0))) + 1;
+		if (buffer_capacity < 2) {
+			buffer_capacity = 2;
+		}
+		return buffer_capacity;
+	}
+	
+	private class BulkStoreImpl implements GenericChannelRequester.BulkStore, Runnable
+	{
+		public BulkStoreImpl(int buffer_size)
+		{
+			m_buffer_size = buffer_size;
+			m_flush_sem = new Semaphore(1);
+			m_flush_completed = new AtomicBoolean(false);
+			m_buffer = create_buffer();
+			m_year = 0;
+			m_write_error = false;
+		}
+		
+		@Override
+		public void addSample(DBRTimeEvent timeevent)
+		{
+			@SuppressWarnings("deprecation")
+			short year = (short)(timeevent.getEventTimeStamp().getYear() + 1900);
+			
+			if (m_buffer.size() >= m_buffer_size || (m_year != 0 && m_year != year)) {
+				if (!need_new_buffer()) {
+					return;
+				}
+			}
+			
+			m_year = year;
+			m_buffer.add(timeevent);
+		}
+		
+		@Override
+		public void complete()
+		{
+			if (m_buffer.size() > 0) {
+				need_new_buffer();
+			}
+			
+			m_flush_completed.set(true);
+			
+			if (m_flush_sem.tryAcquire()) {
+				m_flush_sem.release();
+				unregister_bulk_store();
+			}
+			// else the flush job will unregister_bulk_store
+		}
+		
+		private void unregister_bulk_store()
+		{
+			synchronized (MediatorChannel.this.m_data_lock) {
+				if (this == MediatorChannel.this.m_bulk_store) {
+					MediatorChannel.this.m_bulk_store = null;
+				}
+			}
+		}
+		
+		private ArrayListEventStream create_buffer()
+		{
+			RemotableEventStreamDesc desc = new RemotableEventStreamDesc(m_type, m_full_channel_name, (short)0);
+			return new ArrayListEventStream(m_buffer_size, desc);
+		}
+		
+		private boolean need_new_buffer()
+		{
+			ExecutorService executor = m_mediator.get_bulk_flush_executor();
+			if (executor == null) {
+				return false;
+			}
+			
+			try {
+				m_flush_sem.acquire();
+			} catch (InterruptedException ex) {
+				return false;
+			}
+			
+			try {
+				m_flush_buffer = m_buffer;
+				m_flush_buffer.setYear(m_year);
+				executor.submit(this);
+			}
+			catch (Throwable ex) {
+				m_flush_sem.release();
+				if (ex instanceof RejectedExecutionException) {
+					return false;
+				}
+				throw ex;
+			}
+			
+			m_buffer = create_buffer();
+			m_year = 0;
+			
+			return true;
+		}
+		
+		@Override
+		public void run()
+		{
+			try {
+				boolean channel_destroyed;
+				synchronized (MediatorChannel.this.m_data_lock) {
+					channel_destroyed = m_destroyed;
+				}
+				
+				int count = m_flush_buffer.size();
+				
+				if (!channel_destroyed && count > 0 && !m_write_error) {
+					DBRTimeEvent last_event = (DBRTimeEvent)m_flush_buffer.get(count-1);
+					m_metrics.setElementCount(last_event.getSampleValue().getElementCount());
+					m_metrics.setLastEventFromIOCTimeStamp(last_event.getEventTimeStamp());
+					m_metrics.setSecondsOfLastEvent(System.currentTimeMillis() / 1000);
+					
+					for (Event event : m_flush_buffer) {
+						m_metrics.addEventCounts();
+						m_metrics.addStorageSize((DBRTimeEvent)event);
+					}
+					
+					try (BasicContext basicContext = new BasicContext()) {
+						m_writer.appendData(basicContext, m_full_channel_name, m_flush_buffer);
+					} catch (Exception ex) {
+						m_write_error = true;
+						logTrouble(String.format("Error writing: %s", ex.getMessage()));
+					}
+				}
+			} finally {
+				m_flush_buffer = null;
+				m_flush_sem.release();
+				
+				if (m_flush_completed.get()) {
+					unregister_bulk_store();
+				}
+			}
+		}
+		
+		private final int m_buffer_size;
+		private final Semaphore m_flush_sem;
+		private final AtomicBoolean m_flush_completed;
+		private ArrayListEventStream m_buffer;
+		private ArrayListEventStream m_flush_buffer;
+		private short m_year;
+		private boolean m_write_error;
+	}
+	
+	private static final Timestamp PAST_CUTOFF_TIMESTAMP = TimeUtils.convertFromISO8601String("1991-01-01T00:00:00.000Z");
+	private static final int FUTURE_CUTOFF_SECONDS = 30*60;
+	
+	private final GenericEngineMediator m_mediator;
+	protected final String m_full_channel_name;
+	private final Writer m_writer;
+	protected final ArchDBRTypes m_type;
+	protected Timestamp m_last_archived_timestamp;
+	private final WriterRunnable m_writer_runnable;
+	private boolean m_destroyed;
+	protected final ScopedLogger m_logger;
+	private final Object m_data_lock = new Object();
+	protected final PVMetrics m_metrics;
+	protected final ConcurrentHashMap<String, String> m_metadata = new ConcurrentHashMap();
+	private volatile SampleBuffer m_buffer;
+	protected GenericChannel m_channel;
+	private boolean m_connected;
+	private long m_regain_count;
+	private long m_first_connected;
+	private long m_last_reconnected;
+	private long m_last_disconnected;
+	private BulkStoreImpl m_bulk_store;
+}
+
+class MediatorMetaGet implements GenericMetaGetRequester
+{
+	protected MediatorMetaGet(GenericEngineMediator mediator, String channelName, MetaCompletedListener listener)
+	{
+		m_mediator = mediator;
+		m_channel_name = channelName;
+		m_logger = new ScopedLogger(ScopedLogger.parentScope(mediator.m_metaget_logger), channelName);
+		m_listener = listener;
+	}
+	
+	protected void complete(GenericMetaGet metaget)
+	{
+		m_metaget = metaget;
+		
+		m_logger.info("MetaGet created");
+	}
+	
+	protected void destroy()
+	{
+		m_destroyed = true;
+		
+		m_metaget.destroy();
+		
+		m_logger.info("MetaGet destroyed");
+		
+		if (m_listener != null) {
+			m_listener.completed(new MetaInfo());
+		}
+	}
+	
+	@Override
+	public ScopedLogger getLogger()
+	{
+		return m_logger;
+	}
+	
+	@Override
+	public void metaGetCompleted(final MetaInfo metaInfo)
+	{
+		m_logger.info("MetaGet completed");
+		
+		m_mediator.m_config_service.getEngineContext().getScheduler().execute(new Runnable() { @Override public void run() {
+			metaInfoCompletedFromExecutor(metaInfo);
+		} });
+	}
+	
+	private void metaInfoCompletedFromExecutor(MetaInfo metaInfo)
+	{
+		synchronized (m_mediator) {
+			if (!m_destroyed) {
+				MetaCompletedListener listener = m_listener;
+				m_listener = null;
+				
+				m_mediator.m_metagets.remove(m_channel_name);
+				destroy();
+				
+				listener.completed(metaInfo);
+			}
+		}
+	}
+	
+	private final GenericEngineMediator m_mediator;
+	private final String m_channel_name;
+	protected final ScopedLogger m_logger;
+	protected MetaCompletedListener m_listener;
+	private GenericMetaGet m_metaget;
+	private boolean m_destroyed;
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericEngineRegistry.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericEngineRegistry.java
@@ -1,0 +1,139 @@
+package org.epics.archiverappliance.engine.generic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.log4j.Logger;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.engine.generic.GenericEngineDefinition;
+import org.epics.archiverappliance.engine.generic.GenericEngineMediator;
+
+public class GenericEngineRegistry
+{
+	private static final Logger logger = Logger.getLogger(GenericEngineRegistry.class.getName());
+	
+	public GenericEngineRegistry(ConfigService config_service)
+	{
+		m_config_service = config_service;
+		m_engine_defs = new HashMap<String, GenericEngineDefinition>();
+		m_engines = new ConcurrentHashMap<String, GenericEngineMediator>();
+	}
+
+	public void registerEngineDefinition(GenericEngineDefinition engine_def)
+	{
+		m_engine_defs.put(engine_def.getName(), engine_def);
+	}
+	
+	public void autoloadEnginesAsNeeded()
+	{
+		for (String engine_type : m_engine_defs.keySet()) {
+			String autoload_property = String.format("org.epics.archiverappliance.engine.%s.AutoLoad", engine_type);
+			boolean autoload = Boolean.parseBoolean(m_config_service.getInstallationProperties().getProperty(autoload_property, "false"));
+			if (autoload) {
+				try {
+					getEngine(engine_type);
+				} catch (Exception ex) {
+					logger.error(String.format("Failed to autoload engine '%s'.", engine_type), ex);
+				}
+			}
+		}
+	}
+
+	public synchronized GenericEngineMediator getEngine(String engine_type) throws Exception
+	{
+		if (m_destroyed) {
+			throw new Exception("GenericEngineRegistry is being destroyed");
+		}
+		
+		GenericEngineMediator engine = m_engines.get(engine_type);
+		
+		if (engine == null) {
+			GenericEngineDefinition engine_def = m_engine_defs.get(engine_type);
+			if (engine_def == null) {
+				throw new Exception(String.format("Unknown engine type '%s'", engine_type));
+			}
+			
+			engine = new GenericEngineMediator(engine_def, m_config_service);
+			engine.complete();
+			
+			m_engines.put(engine_type, engine);
+		}
+		
+		return engine;
+	}
+	
+	public static class ParsedUri {
+		public ParsedUri(String engine_name, String path)
+		{
+			this.engine_name = engine_name;
+			this.path = path;
+		}
+		
+		public final String engine_name;
+		public final String path;
+	}
+
+	public ParsedUri readRequestUri(String requestUri)
+	{
+		ParsedUri result = null;
+		
+		for (String this_engine_name : m_engine_defs.keySet()) {
+			String prefix = this_engine_name + ":";
+			if (requestUri.startsWith(prefix)) {
+				result = new ParsedUri(this_engine_name, requestUri.substring(prefix.length()));
+			}
+		}
+		
+		return result;
+	}
+	
+	public GenericEngineMediator getUriEngine(ParsedUri uri) throws Exception
+	{
+		return this.getEngine(uri.engine_name);
+	}
+	
+	public Map<String, GenericEngineMediator> getEngines()
+	{
+		return Collections.unmodifiableMap(m_engines);
+	}
+	
+	public void destroy()
+	{
+		synchronized (this) {
+			if (m_destroyed) {
+				return;
+			}
+			m_destroyed = true;
+		}
+		
+		for (GenericEngineMediator engine : m_engines.values()) {
+			engine.destroy();
+		}
+	}
+	
+	public boolean handleHttpRequest(HttpServletRequest req, HttpServletResponse resp) throws IOException
+	{
+		if (m_destroyed) {
+			throw new IOException("GenericEngineRegistry is being destroyed");
+		}
+		
+		for (GenericEngineMediator engine : m_engines.values()) {
+			if (engine.m_engine.handleHttpRequest(req, resp)) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
+	private final ConfigService m_config_service;
+	private final HashMap<String, GenericEngineDefinition> m_engine_defs;
+	private final ConcurrentHashMap<String, GenericEngineMediator> m_engines;
+	private boolean m_destroyed;
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericEngineRequester.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericEngineRequester.java
@@ -1,0 +1,22 @@
+package org.epics.archiverappliance.engine.generic;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import gov.aps.jca.configuration.Configuration;
+import org.epics.archiverappliance.engine.generic.ScopedLogger;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.config.TypeSystem;
+
+public interface GenericEngineRequester
+{
+	ScopedLogger getLogger();
+	
+	TypeSystem getTypeSystem();
+	
+	Configuration getJcaConfiguration() throws Exception;
+	
+	ScheduledThreadPoolExecutor getScheduler();
+	
+	ConfigService getConfigService();
+	
+	String getProperty(String name, String default_value);
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericMetaGet.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericMetaGet.java
@@ -1,0 +1,6 @@
+package org.epics.archiverappliance.engine.generic;
+
+public interface GenericMetaGet
+{
+	void destroy();
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/GenericMetaGetRequester.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/GenericMetaGetRequester.java
@@ -1,0 +1,11 @@
+package org.epics.archiverappliance.engine.generic;
+
+import org.epics.archiverappliance.config.MetaInfo;
+import org.epics.archiverappliance.engine.generic.ScopedLogger;
+
+public interface GenericMetaGetRequester
+{
+	ScopedLogger getLogger();
+	
+	void metaGetCompleted(MetaInfo metaInfo);
+}

--- a/src/main/org/epics/archiverappliance/engine/generic/ScopedLogger.java
+++ b/src/main/org/epics/archiverappliance/engine/generic/ScopedLogger.java
@@ -1,0 +1,98 @@
+package org.epics.archiverappliance.engine.generic;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.Level;
+
+public class ScopedLogger {
+	public static class ParentSpec {
+		protected ParentSpec(Logger logger, ScopedLogger parent)
+		{
+			this.logger = logger;
+			this.parent = parent;
+		}
+		
+		protected final Logger logger;
+		protected final ScopedLogger parent;
+	}
+	
+	public static ParentSpec parentScope(ScopedLogger scope)
+	{
+		return new ParentSpec(scope.m_logger, scope);
+	}
+	
+	public static ParentSpec parentRoot(Logger logger)
+	{
+		return new ParentSpec(logger, null);
+	}
+	
+	public ScopedLogger(ParentSpec parent_spec, String name)
+	{
+		m_logger = parent_spec.logger;
+		m_parent = parent_spec.parent;
+		m_name = name;
+	}
+	
+	public void log(Level level, Object message)
+	{
+		log(level, message, null);
+	}
+	
+	public void log(Level level, Object message, Throwable th)
+	{
+		if (m_logger.isEnabledFor(level)) {
+			m_logger.log(level, buildMessage(message), th);
+		}
+	}
+	
+	public void debug(Object message)
+	{
+		log(Level.DEBUG, message);
+	}
+	
+	public void info(Object message)
+	{
+		log(Level.INFO, message);
+	}
+	
+	public void warn(Object message)
+	{
+		log(Level.WARN, message);
+	}
+	
+	public void warn(Object message, Throwable th)
+	{
+		log(Level.WARN, message, th);
+	}
+	
+	public void error(Object message)
+	{
+		log(Level.ERROR, message);
+	}
+	
+	public void error(Object message, Throwable th)
+        {
+                log(Level.ERROR, message, th);
+        }
+	
+	public String buildMessage(Object message)
+	{
+		StringBuilder sb = new StringBuilder();
+		build_context_recurser(sb);
+		sb.append(": ");
+		sb.append(message.toString());
+		return sb.toString();
+	}
+	
+	protected void build_context_recurser(StringBuilder sb)
+	{
+		if (m_parent != null) {
+			m_parent.build_context_recurser(sb);
+			sb.append(".");
+		}
+		sb.append(m_name);
+	}
+	
+	protected Logger m_logger;
+	protected ScopedLogger m_parent;
+	protected String m_name;
+}

--- a/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
@@ -49,7 +49,7 @@ import org.epics.archiverappliance.engine.pv.PVMetrics;
  */
 
 @SuppressWarnings("nls")
-abstract public class ArchiveChannel {
+abstract public class ArchiveChannel implements EngineWritable {
 	private static final Logger logger = Logger.getLogger(ArchiveChannel.class);
 
 	/** Throttled log for NaN samples */

--- a/src/main/org/epics/archiverappliance/engine/model/EngineWritable.java
+++ b/src/main/org/epics/archiverappliance/engine/model/EngineWritable.java
@@ -1,0 +1,15 @@
+package org.epics.archiverappliance.engine.model;
+
+import org.epics.archiverappliance.Writer;
+
+/**
+ * Something that can be handled by the engine's writable thread.
+ * @author mshankar
+ *
+ */
+public interface EngineWritable {
+	public String getName();
+	public SampleBuffer getSampleBuffer();
+	public void setlastRotateLogsEpochSeconds(long lastRotationTime);
+	public Writer getWriter();
+}

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -30,7 +30,7 @@ import org.epics.archiverappliance.engine.model.YearListener;
 public class WriterRunnable implements Runnable {
 	private static final Logger logger = Logger.getLogger(WriterRunnable.class);
 	/** Minimum write period [seconds] */
-	private static final double MIN_WRITE_PERIOD = 10.0;
+	private static final double MIN_WRITE_PERIOD = 1.0;
     /**the sample buffer hash map*/
 	final private ConcurrentHashMap<String, SampleBuffer> buffers = new ConcurrentHashMap<String, SampleBuffer>();
 

--- a/src/main/org/epics/archiverappliance/etl/BPLServlet.java
+++ b/src/main/org/epics/archiverappliance/etl/BPLServlet.java
@@ -25,6 +25,7 @@ import org.epics.archiverappliance.etl.bpl.ConsolidatePBFilesForOnePV;
 import org.epics.archiverappliance.etl.bpl.DeletePV;
 import org.epics.archiverappliance.etl.bpl.GetLastKnownEventTimeStamp;
 import org.epics.archiverappliance.etl.bpl.PauseArchivingPV;
+import org.epics.archiverappliance.etl.bpl.AddGatingInterval;
 import org.epics.archiverappliance.etl.bpl.reports.ApplianceMetrics;
 import org.epics.archiverappliance.etl.bpl.reports.ApplianceMetricsDetails;
 import org.epics.archiverappliance.etl.bpl.reports.InstanceReportDetails;
@@ -57,6 +58,7 @@ public class BPLServlet extends HttpServlet {
 		getActions.put("/deletePV", DeletePV.class);
 		getActions.put("/getProcessMetrics", ProcessMetricsReport.class);
 		getActions.put("/getVersion", GetVersion.class);
+		getActions.put("/addGatingInterval", AddGatingInterval.class);
 	}
 
 

--- a/src/main/org/epics/archiverappliance/etl/ETLExecutor.java
+++ b/src/main/org/epics/archiverappliance/etl/ETLExecutor.java
@@ -73,7 +73,7 @@ public class ETLExecutor {
 			logger.info("storage name:"+identifyDest);
 			String sourceStr=dataStores[i-1];
 			ETLSource etlSource = StoragePluginURLParser.parseETLSource(sourceStr, configService);
-			lookupItems.add(new ETLPVLookupItems(pvName, pvTypeInfo.getDBRType(), etlSource, etlDest, i-1, new ETLMetricsForLifetime(i-1), PBThreeTierETLPVLookup.determineOutOfSpaceHandling(configService), etlLookup.getGatingState()));
+			lookupItems.add(new ETLPVLookupItems(pvName, pvTypeInfo.getDBRType(), etlSource, etlDest, i-1, new ETLMetricsForLifetime(i-1), PBThreeTierETLPVLookup.determineOutOfSpaceHandling(configService), PBThreeTierETLPVLookup.determineFreeSpaceClearance(configService), etlLookup.getGatingState()));
 			if(storageName.equals(identifyDest)){
 				break;
 			}

--- a/src/main/org/epics/archiverappliance/etl/ETLExecutor.java
+++ b/src/main/org/epics/archiverappliance/etl/ETLExecutor.java
@@ -14,6 +14,7 @@ import org.epics.archiverappliance.etl.common.ETLJob;
 import org.epics.archiverappliance.etl.common.ETLMetricsForLifetime;
 import org.epics.archiverappliance.etl.common.ETLPVLookupItems;
 import org.epics.archiverappliance.etl.common.PBThreeTierETLPVLookup;
+import org.epics.archiverappliance.etl.common.DefaultStorageMetricsContext;
 
 /**
  * Run ETLs for one PV; mostly for unit tests..
@@ -64,6 +65,8 @@ public class ETLExecutor {
 			throw new IOException("The pv " + pvName + " has not enough stores.");
 		}
 		
+		DefaultStorageMetricsContext metricsContext = new DefaultStorageMetricsContext();
+		
 		lookupItems = new LinkedList<ETLPVLookupItems>();
 		for(int i=1;i<dataStores.length;i++){
 			String destStr=dataStores[i];
@@ -73,7 +76,7 @@ public class ETLExecutor {
 			logger.info("storage name:"+identifyDest);
 			String sourceStr=dataStores[i-1];
 			ETLSource etlSource = StoragePluginURLParser.parseETLSource(sourceStr, configService);
-			lookupItems.add(new ETLPVLookupItems(pvName, pvTypeInfo.getDBRType(), etlSource, etlDest, i-1, new ETLMetricsForLifetime(i-1), PBThreeTierETLPVLookup.determineOutOfSpaceHandling(configService), PBThreeTierETLPVLookup.determineFreeSpaceClearance(configService), etlLookup.getGatingState()));
+			lookupItems.add(new ETLPVLookupItems(pvName, pvTypeInfo.getDBRType(), etlSource, etlDest, i-1, new ETLMetricsForLifetime(i-1, metricsContext), PBThreeTierETLPVLookup.determineOutOfSpaceHandling(configService), PBThreeTierETLPVLookup.determineFreeSpaceClearance(configService), etlLookup.getGatingState()));
 			if(storageName.equals(identifyDest)){
 				break;
 			}

--- a/src/main/org/epics/archiverappliance/etl/ETLExecutor.java
+++ b/src/main/org/epics/archiverappliance/etl/ETLExecutor.java
@@ -73,7 +73,7 @@ public class ETLExecutor {
 			logger.info("storage name:"+identifyDest);
 			String sourceStr=dataStores[i-1];
 			ETLSource etlSource = StoragePluginURLParser.parseETLSource(sourceStr, configService);
-			lookupItems.add(new ETLPVLookupItems(pvName, pvTypeInfo.getDBRType(), etlSource, etlDest, i-1, new ETLMetricsForLifetime(i-1), PBThreeTierETLPVLookup.determineOutOfSpaceHandling(configService)));
+			lookupItems.add(new ETLPVLookupItems(pvName, pvTypeInfo.getDBRType(), etlSource, etlDest, i-1, new ETLMetricsForLifetime(i-1), PBThreeTierETLPVLookup.determineOutOfSpaceHandling(configService), etlLookup.getGatingState()));
 			if(storageName.equals(identifyDest)){
 				break;
 			}

--- a/src/main/org/epics/archiverappliance/etl/bpl/AddGatingInterval.java
+++ b/src/main/org/epics/archiverappliance/etl/bpl/AddGatingInterval.java
@@ -1,0 +1,57 @@
+package org.epics.archiverappliance.etl.bpl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.log4j.Logger;
+import org.epics.archiverappliance.common.BPLAction;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
+import org.json.simple.JSONValue;
+
+/**
+ * Add interval to keep data for with respect to ETL gating.
+ */
+public class AddGatingInterval implements BPLAction {
+	private static final Logger logger = Logger.getLogger(AddGatingInterval.class);
+	
+	@Override
+	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
+		String gatingScope = req.getParameter("gatingScope");
+		if(gatingScope == null || gatingScope.equals("")) {
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+		
+		String startStr = req.getParameter("startMillis");
+		String endStr = req.getParameter("endMillis");
+		if (startStr == null || endStr == null) {
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+		
+		long startMillis;
+		long endMillis;
+		try {
+			startMillis = Long.parseLong(startStr);
+			endMillis = Long.parseLong(endStr);
+		} catch (NumberFormatException ex) {
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+		
+		configService.getETLLookup().getGatingState().keepTimeInterval(gatingScope, startMillis, endMillis);
+		
+		try (PrintWriter out = resp.getWriter()) {
+			resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+			HashMap<String, Object> infoValues = new HashMap<String, Object>();
+			infoValues.put("status", "ok");
+			infoValues.put("desc", "successfully merged gating interval");
+			out.println(JSONValue.toJSONString(infoValues));
+		}
+	}
+}

--- a/src/main/org/epics/archiverappliance/etl/bpl/reports/ApplianceMetrics.java
+++ b/src/main/org/epics/archiverappliance/etl/bpl/reports/ApplianceMetrics.java
@@ -47,7 +47,7 @@ public class ApplianceMetrics implements BPLAction {
 			double maxETLPercentage = 0.0; 
 			long currentEpochSeconds = TimeUtils.getCurrentEpochSeconds();
 			for(ETLMetricsForLifetime metricForLifetime : metricsForLifetime) {
-				double etlPercentage = (metricForLifetime.getTimeForOverallETLInMilliSeconds()/1000)*100/(currentEpochSeconds - metricForLifetime.getStartOfMetricsMeasurementInEpochSeconds());
+				double etlPercentage = ((double)metricForLifetime.getTimeForOverallETLInMilliSeconds()/1000)*100/(currentEpochSeconds - metricForLifetime.getStartOfMetricsMeasurementInEpochSeconds());
 				maxETLPercentage = Math.max(etlPercentage, maxETLPercentage);
 				metrics.put("totalETLRuns("+metricForLifetime.getLifeTimeId()+")", Long.toString(metricForLifetime.getTotalETLRuns()));
 				metrics.put("timeForOverallETLInSeconds("+metricForLifetime.getLifeTimeId()+")", Long.toString(metricForLifetime.getTimeForOverallETLInMilliSeconds()/1000));

--- a/src/main/org/epics/archiverappliance/etl/common/DefaultStorageMetricsContext.java
+++ b/src/main/org/epics/archiverappliance/etl/common/DefaultStorageMetricsContext.java
@@ -1,0 +1,32 @@
+package org.epics.archiverappliance.etl.common;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import org.apache.log4j.Logger;
+import org.epics.archiverappliance.etl.StorageMetricsContext;
+import org.epics.archiverappliance.utils.nio.ArchPaths;
+
+public class DefaultStorageMetricsContext implements StorageMetricsContext {
+	private static Logger logger = Logger.getLogger(DefaultStorageMetricsContext.class.getName());
+	
+	private HashMap<String, FileStore> storageMetricsFileStores = new HashMap<String, FileStore>();
+	
+	@Override
+	public synchronized FileStore getFileStore(String rootFolder) throws IOException {
+		FileStore fileStore = this.storageMetricsFileStores.get(rootFolder);
+		if(fileStore == null) { 
+			try(ArchPaths paths = new ArchPaths()) {
+				Path rootF = paths.get(rootFolder);
+				fileStore = Files.getFileStore(rootF);
+				this.storageMetricsFileStores.put(rootFolder, fileStore);
+				logger.debug("Adding filestore to ETLMetricsForLifetime cache for rootFolder " + rootFolder);
+			}
+		} else { 
+			logger.debug("Filestore for rootFolder " + rootFolder + " is already in ETLMetricsForLifetime cache");
+		}
+		return fileStore;
+	}
+}

--- a/src/main/org/epics/archiverappliance/etl/common/ETLGatingState.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLGatingState.java
@@ -1,0 +1,148 @@
+package org.epics.archiverappliance.etl.common;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.TreeSet;
+import org.apache.log4j.Logger;
+import org.epics.archiverappliance.config.ConfigService;
+
+public class ETLGatingState {
+	protected static Logger logger = Logger.getLogger(ETLGatingState.class.getName());
+
+	protected final ConfigService m_configService;
+	private final Object m_lock = new Object();
+	private final HashMap<String, ETLGatingScope> m_scopes = new HashMap<String, ETLGatingScope>();
+
+	/**
+	* Creates the gating state instance.
+	*/
+	public ETLGatingState(ConfigService configService)
+	{
+		m_configService = configService;
+	}
+
+	/**
+	* Remember that samples from a specific time interval should pass the ETL gate.
+	*
+	* @param scopeName - The name of the ETL gating scope to work in. Nonexisting scopes
+	*                    are created automatically.
+	* @param startMillis - The interval start time in 1970-epoch milliseconds (inclusive).
+	* @param endMillis - The interval end time in 1970-epoch milliseconds (exclusive).
+	*/
+	public void keepTimeInterval(String scopeName, long startMillis, long endMillis) {
+		synchronized (m_lock) {
+			ETLGatingScope scope = getScope(scopeName);
+			scope.keepTimeInterval(startMillis, endMillis);
+		}
+	}
+
+	/**
+	* Determines whether samples from a specific time interval should pass the ETL gate.
+	*
+	* @param scopeName - The name of the ETL gating scope to work in. Nonexisting scopes
+	*                    are created automatically.
+	* @param startMillis - The interval start time in 1970-epoch milliseconds (inclusive).
+	* @param endMillis - The interval end time in 1970-epoch milliseconds (exclusive).
+	*/
+	public boolean shouldIntervalBeKept(String scopeName, long startMillis, long endMillis) {
+		synchronized (m_lock) {
+			ETLGatingScope scope = getScope(scopeName);
+			return scope.shouldIntervalBeKept(startMillis, endMillis);
+		}
+	}
+
+	private ETLGatingScope getScope(String scopeName) {
+		if (!m_scopes.containsKey(scopeName)) {
+			logger.info("Creating new ETL gating scope with name = " + scopeName);
+			m_scopes.put(scopeName, new ETLGatingScope(this, scopeName));
+		}
+		return m_scopes.get(scopeName);
+	}
+}
+
+class ETLGatingScope {
+	private static int DEFAULT_MAX_INTERVALS = 100;
+
+	private final int m_maxIntervals;
+
+	// Here we keep the time intervals which define the data that should pass the ETL gate.
+	// They are considered as half-open [) intervals, with the invariant that they are
+	// mutually strictly non-overlapping and non-touching. The TreeSet keeps them in their
+	// natural order.
+	private final TreeSet<ETLGatingInterval> m_intervals = new TreeSet<ETLGatingInterval>();
+
+	public ETLGatingScope(ETLGatingState gatingState, String name)
+	{
+		String maxIntervalsProperty = "org.epics.archiverappliance.etl.common.GatingMaxIntervals_" + name;
+		m_maxIntervals = Integer.parseInt(gatingState.m_configService.getInstallationProperties().getProperty(maxIntervalsProperty, Integer.toString(DEFAULT_MAX_INTERVALS)));
+	}
+
+	public void keepTimeInterval(long start, long end) {
+		// Disallow non-positive intervals.
+		if (end <= start) {
+			return;
+		}
+		
+		// The merging algorithm is as follows: we remove all existing intervals
+		// which overlap with or touch the request interval, and replace them with
+		// a new interval which is a union of all removed intervals and the request
+		// interval. This union interval is defined by the minimum of the start
+		// points and the maximum of end points.
+		ETLGatingInterval requestInterval = new ETLGatingInterval(start, end);
+		long merged_start = requestInterval.start;
+		long merged_end = requestInterval.end;
+		Iterator<ETLGatingInterval> iter = m_intervals.iterator();
+		while (iter.hasNext()) {
+			ETLGatingInterval interval = iter.next();
+			if (interval.overlapsWithOrTouches(requestInterval)) {
+				iter.remove();
+				merged_start = Math.min(merged_start, interval.start);
+				merged_end = Math.max(merged_end, interval.end);
+			}
+		}
+		m_intervals.add(new ETLGatingInterval(merged_start, merged_end));
+		
+		// Possibly delete intervals from the beginning to keep the interval
+		// list size within the bound.
+		while (m_intervals.size() > m_maxIntervals) {
+			m_intervals.pollFirst();
+		}
+	}
+
+	public boolean shouldIntervalBeKept(long start, long end) {
+		// The interval should be kept if it overlaps with any of the
+		// intervals in the list.
+		ETLGatingInterval queryInterval = new ETLGatingInterval(start, end);
+		for (ETLGatingInterval interval : m_intervals) {
+			if (interval.overlapsWith(queryInterval)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+class ETLGatingInterval implements Comparable<ETLGatingInterval> {
+	public final long start;
+	public final long end;
+
+	public ETLGatingInterval(long start, long end) {
+		this.start = start;
+		this.end = end;
+	}
+
+	@Override
+	public int compareTo(ETLGatingInterval other) {
+		Long a = new Long(this.start);
+		Long b = new Long(other.start);
+		return a.compareTo(b);
+	}
+
+	public boolean overlapsWithOrTouches(ETLGatingInterval other) {
+		return (other.end >= this.start && other.start <= this.end);
+	}
+
+	public boolean overlapsWith(ETLGatingInterval other) {
+		return (other.end > this.start && other.start < this.end);
+	}
+}

--- a/src/main/org/epics/archiverappliance/etl/common/ETLJob.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLJob.java
@@ -48,9 +48,7 @@ public class ETLJob implements Runnable {
 		try { 
 			exceptionFromLastRun = null;
 			if(this.runAsIfAtTime == null) { 
-				// We run ETL as if it were 10% of src partition seconds ago to give the previous lifetime time to finish.  
-				long padding = Math.round(this.lookupItem.getETLSource().getPartitionGranularity().getApproxSecondsPerChunk()*0.1);
-				Timestamp processingTime = TimeUtils.convertFromEpochSeconds(TimeUtils.getCurrentEpochSeconds() - padding, 0);
+				Timestamp processingTime = TimeUtils.convertFromEpochSeconds(TimeUtils.getCurrentEpochSeconds(), 0);
 				this.processETL(processingTime);
 			} else { 
 				this.processETL(runAsIfAtTime);

--- a/src/main/org/epics/archiverappliance/etl/common/ETLJob.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLJob.java
@@ -124,7 +124,7 @@ public class ETLJob implements Runnable {
 					long sizeOfSrcStream = infoItem.getSize();
 					totalSrcBytes += sizeOfSrcStream;
 					if(sizeOfSrcStream > 0 && destMetrics != null) { 
-						long freeSpace = destMetrics.getUsableSpace(lookupItem.getMetricsForLifetime());
+						long freeSpace = destMetrics.getUsableSpace(lookupItem.getMetricsForLifetime().getMetricsContext());
 						long freeSpaceClearance = lookupItem.getFreeSpaceClearance();
 						// We leave space for at least freeSpaceClearance in the dest so that:
 						// - You can login and have some room to repair damage coming in from an out of space condition.

--- a/src/main/org/epics/archiverappliance/etl/common/ETLJob.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLJob.java
@@ -158,7 +158,7 @@ public class ETLJob implements Runnable {
 							logger.warn("Processing ETLInfo with key = " + infoItem.getKey() + " for PV " + pvName + "itemInfo partitionGranularity = " + infoItem.getGranularity().toString());
 						}
 					} catch(IOException ex) {
-						logger.error("Exception processing " + infoItem.getKey(), ex);
+						logger.error("Exception processing " + infoItem.getKey() + ": " + ex.getMessage());
 						if (handleFailedItem(infoItem, deleteList)) {
 							continue;
 						} else {
@@ -177,7 +177,7 @@ public class ETLJob implements Runnable {
 					commitSuccessful = curETLDest.commitETLAppendData(pvName, etlContext);
 					time4commitETLAppendData = time4commitETLAppendData+System.currentTimeMillis()-time7;
 				} catch (IOException e) {
-					logger.error("IOException from commitETLAppendData ", e);
+					logger.error("Exception from commitETLAppendData: " + e.getMessage());
 				}
 				
 				// Decide which source items should be deleted.
@@ -235,12 +235,10 @@ public class ETLJob implements Runnable {
 	
 	private boolean handleFailedItem(ETLInfo infoItem, List<ETLInfo> deleteList) {
 		if(getEffectiveOutOfSpaceHandling() == OutOfSpaceHandling.DELETE_SRC_STREAMS_WHEN_OUT_OF_SPACE) {
-			logger.error("Deleting src stream " + infoItem.getKey());
 			deleteList.add(infoItem);
 			lookupItem.outOfSpaceChunkDeleted();
 			return true;
 		} else { // outOfSpaceHandling == OutOfSpaceHandling.SKIP_ETL_WHEN_OUT_OF_SPACE
-			logger.warn("Skipping ETL this time for pv " + lookupItem.getPvName());
 			return false;
 		}
 	}

--- a/src/main/org/epics/archiverappliance/etl/common/ETLPVLookupItems.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLPVLookupItems.java
@@ -46,11 +46,12 @@ public class ETLPVLookupItems {
 	private ScheduledFuture<?> cancellingFuture;
 	
 	private OutOfSpaceHandling outOfSpaceHandling;
+	private long freeSpaceClearance;
 	private long outOfSpaceChunksDeleted = 0;
 	
 	private final ETLGatingState gatingState;
 	
-	public ETLPVLookupItems(String pvName, ArchDBRTypes dbrType, ETLSource source, ETLDest dest, int lifetimeorder, ETLMetricsForLifetime metricsForLifetime, OutOfSpaceHandling outOfSpaceHandling, ETLGatingState gatingState) {
+	public ETLPVLookupItems(String pvName, ArchDBRTypes dbrType, ETLSource source, ETLDest dest, int lifetimeorder, ETLMetricsForLifetime metricsForLifetime, OutOfSpaceHandling outOfSpaceHandling, long freeSpaceClearance, ETLGatingState gatingState) {
 		this.pvName = pvName;
 		this.dbrType = dbrType;
 		this.source = source;
@@ -58,6 +59,7 @@ public class ETLPVLookupItems {
 		this.lifetimeorder = lifetimeorder;
 		this.metricsForLifetime = metricsForLifetime;
 		this.outOfSpaceHandling = outOfSpaceHandling;
+		this.freeSpaceClearance = freeSpaceClearance;
 		this.gatingState = gatingState;
 	}
 
@@ -193,6 +195,10 @@ public class ETLPVLookupItems {
 		return outOfSpaceHandling;
 	}
 
+	public long getFreeSpaceClearance() {
+		return freeSpaceClearance;
+	}
+	
 	public long getOutOfSpaceChunksDeleted() {
 		return outOfSpaceChunksDeleted;
 	}

--- a/src/main/org/epics/archiverappliance/etl/common/ETLPVLookupItems.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLPVLookupItems.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ScheduledFuture;
 import org.epics.archiverappliance.config.ArchDBRTypes;
 import org.epics.archiverappliance.etl.ETLDest;
 import org.epics.archiverappliance.etl.ETLSource;
+import org.epics.archiverappliance.etl.common.ETLGatingState;
 
 /**
  * A POJO for PV name, ETLSource, and ETLDest items,
@@ -47,8 +48,9 @@ public class ETLPVLookupItems {
 	private OutOfSpaceHandling outOfSpaceHandling;
 	private long outOfSpaceChunksDeleted = 0;
 	
+	private final ETLGatingState gatingState;
 	
-	public ETLPVLookupItems(String pvName, ArchDBRTypes dbrType, ETLSource source, ETLDest dest, int lifetimeorder, ETLMetricsForLifetime metricsForLifetime, OutOfSpaceHandling outOfSpaceHandling) {
+	public ETLPVLookupItems(String pvName, ArchDBRTypes dbrType, ETLSource source, ETLDest dest, int lifetimeorder, ETLMetricsForLifetime metricsForLifetime, OutOfSpaceHandling outOfSpaceHandling, ETLGatingState gatingState) {
 		this.pvName = pvName;
 		this.dbrType = dbrType;
 		this.source = source;
@@ -56,6 +58,7 @@ public class ETLPVLookupItems {
 		this.lifetimeorder = lifetimeorder;
 		this.metricsForLifetime = metricsForLifetime;
 		this.outOfSpaceHandling = outOfSpaceHandling;
+		this.gatingState = gatingState;
 	}
 
 	public int getLifetimeorder() {
@@ -215,5 +218,9 @@ public class ETLPVLookupItems {
 	 */
 	public ETLMetricsForLifetime getMetricsForLifetime() {
 		return metricsForLifetime;
+	}
+	
+	public ETLGatingState getGatingState() {
+		return gatingState;
 	}
 }

--- a/src/main/org/epics/archiverappliance/etl/common/PBThreeTierETLPVLookup.java
+++ b/src/main/org/epics/archiverappliance/etl/common/PBThreeTierETLPVLookup.java
@@ -168,7 +168,11 @@ public final class PBThreeTierETLPVLookup {
 					// We then compute the start of the next partition.
 					long nextPartitionFirstSec = TimeUtils.getNextPartitionFirstSecond(epochSeconds, etlSource.getPartitionGranularity());
 					// Add a small buffer to this
-					long nextExpectedETLRunInSecs = nextPartitionFirstSec + 5*60*(etllifetimeid+1);
+					long bufferSecs = 5*60*(etllifetimeid+1);
+					if(etllifetimeid == 0) {
+						bufferSecs = Math.min(bufferSecs, delaybetweenETLJobs/20);
+					}
+					long nextExpectedETLRunInSecs = nextPartitionFirstSec + bufferSecs;
 					// We compute the initial delay so that the ETL jobs run at a predictable time. 
 					long initialDelay = nextExpectedETLRunInSecs - epochSeconds;
 					// We schedule a ETLPVLookupItems with the appropriate thread using an ETLJob

--- a/src/main/org/epics/archiverappliance/etl/common/PBThreeTierETLPVLookup.java
+++ b/src/main/org/epics/archiverappliance/etl/common/PBThreeTierETLPVLookup.java
@@ -155,7 +155,7 @@ public final class PBThreeTierETLPVLookup {
 					ETLSource etlSource = StoragePluginURLParser.parseETLSource(sourceStr, configService);
 					String destStr=dataSources[etllifetimeid+1];
 					ETLDest etlDest = StoragePluginURLParser.parseETLDest(destStr, configService);
-					ETLPVLookupItems etlpvLookupItems = new ETLPVLookupItems(pvName, typeInfo.getDBRType(), etlSource, etlDest, etllifetimeid, applianceMetrics.get(etllifetimeid), determineOutOfSpaceHandling(configService), gatingState);
+					ETLPVLookupItems etlpvLookupItems = new ETLPVLookupItems(pvName, typeInfo.getDBRType(), etlSource, etlDest, etllifetimeid, applianceMetrics.get(etllifetimeid), determineOutOfSpaceHandling(configService), determineFreeSpaceClearance(configService), gatingState);
 					if(etlDest instanceof StorageMetrics) { 
 						// At least on some of the test machines, checking free space seems to take the longest time. In this, getting the fileStore seems to take the longest time. 
 						// The plainPB plugin caches the fileStore; so we make a call once when adding to initialize this upfront.
@@ -338,6 +338,10 @@ public final class PBThreeTierETLPVLookup {
 	public void addETLJobsForUnitTests(String pvName, PVTypeInfo typeInfo) {
 		logger.warn("This message should only be called from the unit tests.");
 		addETLJobs(pvName, typeInfo);
+	}
+
+	public static long determineFreeSpaceClearance(ConfigService configService) { 
+		return Long.parseLong(configService.getInstallationProperties().getProperty("org.epics.archiverappliance.etl.common.FreeSpaceClearance", Long.toString(1024*1024)));
 	}
 
 	public ETLGatingState getGatingState() {

--- a/src/main/org/epics/archiverappliance/etl/common/PBThreeTierETLPVLookup.java
+++ b/src/main/org/epics/archiverappliance/etl/common/PBThreeTierETLPVLookup.java
@@ -137,7 +137,7 @@ public final class PBThreeTierETLPVLookup {
 			logger.debug("Adding etl jobs for pv " + pvName + " for chunkkey " + chunkKey);
 			String[] dataSources = typeInfo.getDataStores();
 			if(dataSources == null ||  dataSources.length < 2) { 
-				logger.warn("Skipping adding PV to ETL as it has less than 2 datasources" + pvName);
+				logger.debug("Skipping adding PV to ETL as it has less than 2 datasources" + pvName);
 				return;
 			}
 

--- a/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
+++ b/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
@@ -26,6 +26,7 @@ import org.epics.archiverappliance.mgmt.bpl.AbortArchiveRequestForAppliance;
 import org.epics.archiverappliance.mgmt.bpl.AddAliasAction;
 import org.epics.archiverappliance.mgmt.bpl.AddExternalArchiverServer;
 import org.epics.archiverappliance.mgmt.bpl.AddExternalArchiverServerArchives;
+import org.epics.archiverappliance.mgmt.bpl.AddETLGatingInterval;
 import org.epics.archiverappliance.mgmt.bpl.AggregatedApplianceInfo;
 import org.epics.archiverappliance.mgmt.bpl.ArchivePVAction;
 import org.epics.archiverappliance.mgmt.bpl.ArchivedPVsNotInListAction;
@@ -130,8 +131,8 @@ public class BPLServlet extends HttpServlet {
 		addAction("/modifyMetaFields", ModifyMetaFieldsAction.class);
 		addAction("/getNamedFlag", NamedFlagsGet.class);
 		addAction("/setNamedFlag", NamedFlagsSet.class);
+		addAction("/addETLGatingInterval", AddETLGatingInterval.class);
 		
-
 		// BPL related to reports
 		addAction("/getNeverConnectedPVs", NeverConnectedPVsAction.class);
 		addAction("/getNeverConnectedPVsForThisAppliance", NeverConnectedPVsForThisAppliance.class);

--- a/src/main/org/epics/archiverappliance/mgmt/archivepv/ArchivePVState.java
+++ b/src/main/org/epics/archiverappliance/mgmt/archivepv/ArchivePVState.java
@@ -48,7 +48,7 @@ public class ArchivePVState {
 		this.myIdentity = this.configService.getMyApplianceInfo().getIdentity();
 	}
 
-	public void nextStep() {
+	public synchronized void nextStep() {
 		try { 
 			logger.debug("Archive workflow for pv " + pvName + " in state " + currentState);
 				switch(currentState) {
@@ -244,7 +244,7 @@ public class ArchivePVState {
 		}
 	}
 
-	public boolean hasNotConnectedSoFar() {
+	public synchronized boolean hasNotConnectedSoFar() {
 		return this.currentState.equals(ArchivePVState.ArchivePVStateMachine.METAINFO_REQUESTED) || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.ABORTED);
 	}
 
@@ -274,22 +274,22 @@ public class ArchivePVState {
 	}
 	
 	
-	public void metaInfoRequestAcknowledged() { 
+	public synchronized void metaInfoRequestAcknowledged() { 
 		metaInfoRequestedSubmitted = TimeUtils.now();
 		this.currentState = ArchivePVStateMachine.METAINFO_REQUESTED;
 	}
 	
-	public void metaInfoObtained(MetaInfo metaInfo) { 
+	public synchronized void metaInfoObtained(MetaInfo metaInfo) { 
 		this.metaInfo = metaInfo;
 		this.currentState = ArchivePVStateMachine.METAINFO_OBTAINED;
 	}
 	
-	public void errorGettingMetaInfo() { 
+	public synchronized void errorGettingMetaInfo() { 
 		abortReason = "Error getting meta info";
 		this.currentState = ArchivePVStateMachine.ABORTED;
 	}	
 	
-	public void confirmedStartedArchivingPV() {
+	public synchronized void confirmedStartedArchivingPV() {
 		this.currentState = ArchivePVStateMachine.ARCHIVING;
 	}
 
@@ -377,7 +377,7 @@ public class ArchivePVState {
 	/**
 	 * @return The current archiving state machine state
 	 */
-	public ArchivePVStateMachine getCurrentState() {
+	public synchronized ArchivePVStateMachine getCurrentState() {
 		return currentState;
 	}
 
@@ -385,7 +385,7 @@ public class ArchivePVState {
 		return pvName;
 	}
 
-	public Timestamp getMetaInfoRequestedSubmitted() {
+	public synchronized Timestamp getMetaInfoRequestedSubmitted() {
 		return metaInfoRequestedSubmitted;
 	}
 }

--- a/src/main/org/epics/archiverappliance/mgmt/archivepv/CapacityPlanningBPL.java
+++ b/src/main/org/epics/archiverappliance/mgmt/archivepv/CapacityPlanningBPL.java
@@ -41,6 +41,7 @@ public class CapacityPlanningBPL {
          */
         private static float percentageLimitation=80;
         private static Logger configlogger = Logger.getLogger("config." + CapacityPlanningBPL.class.getName());
+        private static final String SKIP_CAPACITY_PLANNING_PROPERTY = "org.epics.archiverappliance.mgmt.archivepv.SkipCapacityPlanning";
  
    /***
     * get the appliance for this pv.
@@ -53,7 +54,11 @@ public class CapacityPlanningBPL {
     * in this case, this method will return the ApplianceInfo of the local  appliance
     */
         public static ApplianceInfo pickApplianceForPV(String pvName, ConfigService configService,PVTypeInfo pvTypeInfo) throws IOException {
-             
+                boolean skipCapacityPlanning = Boolean.parseBoolean(configService.getInstallationProperties().getProperty(SKIP_CAPACITY_PLANNING_PROPERTY, "false"));
+                if (skipCapacityPlanning) {
+                        return configService.getMyApplianceInfo();
+                }
+                
                 try{
                 String [] dataStores=pvTypeInfo.getDataStores();
              

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/AddETLGatingInterval.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/AddETLGatingInterval.java
@@ -1,0 +1,102 @@
+package org.epics.archiverappliance.mgmt.bpl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URLEncoder;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.log4j.Logger;
+import org.epics.archiverappliance.common.BPLAction;
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.config.ApplianceInfo;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
+/**
+ * Add interval to keep data for with respect to ETL gating.
+ * Forward the request to the ETL application of all appliances.
+ */
+public class AddETLGatingInterval implements BPLAction {
+	private static final Logger logger = Logger.getLogger(AddETLGatingInterval.class);
+	
+	@Override
+	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
+		String gatingScope = req.getParameter("gatingScope");
+		if(gatingScope == null || gatingScope.equals("")) {
+			logger.warn("Missing gatingScope parameter");
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+		
+		long startMillis;
+		try {
+			startMillis = readTimeParameter(req, "from");
+		} catch (Exception ex) {
+			logger.warn("Bad 'from' parameter", ex);
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+		
+		long endMillis;
+		try {
+			endMillis = readTimeParameter(req, "to");
+		} catch (Exception ex) {
+			logger.warn("Bad 'to' parameter", ex);
+			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+		
+		logger.info(String.format("Forwarding ETL gating interval request, gatingScope=%s from=%s to=%s",
+			gatingScope, new Timestamp(startMillis), new Timestamp(endMillis)));
+		
+		LinkedList<String> etlReqUrls = new LinkedList<String>();
+		for(ApplianceInfo info : configService.getAppliancesInCluster()) {
+			etlReqUrls.add(String.format("%s/addGatingInterval?gatingScope=%s&startMillis=%d&endMillis=%d",
+				info.getEtlURL(), URLEncoder.encode(gatingScope, "UTF-8"), startMillis, endMillis));
+		}
+		
+		HashMap<String, Object> infoValues = new HashMap<String, Object>();
+		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+		try (PrintWriter out = resp.getWriter()) {
+			boolean successful = true;
+			for (String etlReqUrl : etlReqUrls) {
+				JSONObject reqResp = GetUrlContent.getURLContentAsJSONObject(etlReqUrl);
+				if (!(reqResp != null && reqResp.containsKey("status") && reqResp.get("status").equals("ok"))) {
+					successful = false;
+				}
+			}
+			infoValues.put("status", successful ? "ok" : "no");
+			infoValues.put("desc", "forwarded ETL gating request");
+			out.println(JSONValue.toJSONString(infoValues));
+		}
+	}
+	
+	private long readTimeParameter(HttpServletRequest req, String parameterName) throws Exception {
+		String strValue = req.getParameter(parameterName);
+		if (strValue == null) {
+			throw new Exception("missing parameter");
+		}
+		
+		long millis;
+		try {
+			millis = Long.parseLong(strValue);
+		} catch (NumberFormatException ex) {
+			try {
+				Timestamp ts = TimeUtils.convertFromISO8601String(strValue);
+				millis = ts.getTime();
+			} catch (IllegalArgumentException ex1) {
+				throw new Exception("incorrect value (neither milliseconds integer nor ISO8601)");
+			}
+		}
+		
+		return millis;
+	}
+}

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ChannelArchiverImport.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ChannelArchiverImport.java
@@ -1,0 +1,27 @@
+package org.epics.archiverappliance.mgmt.bpl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.config.ChannelArchiver.PVConfig;
+import org.epics.archiverappliance.mgmt.policy.PolicyConfig.SamplingMethod;
+
+public class ChannelArchiverImport {
+	private static final Logger logger = Logger.getLogger(ChannelArchiverImport.class);
+	
+	public static void importPV(PVConfig pvConfig, PrintWriter out, List<String> fieldsAsPartOfStream, boolean skipCapacityPlanning, ConfigService configService) throws IOException {
+		boolean scan = !pvConfig.isMonitor();
+		float samplingPeriod = pvConfig.getPeriod();
+		if (logger.isDebugEnabled()) {
+			String msg = "Adding " + pvConfig.getPVName() + " using " + (scan ? SamplingMethod.SCAN : SamplingMethod.MONITOR) + " and a period of " + samplingPeriod;
+			if (pvConfig.getPolicy() != null) {
+				msg = msg + " and policy " + pvConfig.getPolicy();
+			}
+			logger.debug(msg);
+		}
+		ArchivePVAction.archivePV(out, pvConfig.getPVName(), true, scan ? SamplingMethod.SCAN : SamplingMethod.MONITOR, samplingPeriod, null, pvConfig.getPolicy(), null, skipCapacityPlanning, configService, fieldsAsPartOfStream);
+	}
+}

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ImportChannelArchiverConfigAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ImportChannelArchiverConfigAction.java
@@ -51,10 +51,7 @@ public class ImportChannelArchiverConfigAction implements BPLAction {
 			LinkedList<PVConfig> pvConfigs = EngineConfigParser.importEngineConfig(is);
 			for(PVConfig pvConfig : pvConfigs) {
 				if(isFirst) { isFirst = false; } else { out.println(","); }
-				boolean scan = !pvConfig.isMonitor();
-				float samplingPeriod = pvConfig.getPeriod();
-				if(logger.isDebugEnabled()) logger.debug("Adding " + pvConfig.getPVName() + " using " + (scan ? SamplingMethod.SCAN : SamplingMethod.MONITOR) + " and a period of " + samplingPeriod);
-				ArchivePVAction.archivePV(out, pvConfig.getPVName(), true, scan ? SamplingMethod.SCAN : SamplingMethod.MONITOR, samplingPeriod, null, null, null, false, configService, fieldsAsPartOfStream);
+				ChannelArchiverImport.importPV(pvConfig, out, fieldsAsPartOfStream, false, configService);
 			}
 			out.println("]");
 		} catch(Exception ex) {

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/UploadChannelArchiverConfigAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/UploadChannelArchiverConfigAction.java
@@ -67,10 +67,7 @@ public class UploadChannelArchiverConfigAction implements BPLAction {
 						is.reset();
 						LinkedList<PVConfig> pvConfigs = EngineConfigParser.importEngineConfig(is);
 						for(PVConfig pvConfig : pvConfigs) {
-							boolean scan = !pvConfig.isMonitor();
-							float samplingPeriod = pvConfig.getPeriod();
-							if(logger.isDebugEnabled()) logger.debug("Adding " + pvConfig.getPVName() + " using " + (scan ? SamplingMethod.SCAN : SamplingMethod.MONITOR) + " and a period of " + samplingPeriod);
-							ArchivePVAction.archivePV(out, pvConfig.getPVName(), true, scan ? SamplingMethod.SCAN : SamplingMethod.MONITOR, samplingPeriod, null, null, null, false, configService, fieldsAsPartOfStream);
+							ChannelArchiverImport.importPV(pvConfig, out, fieldsAsPartOfStream, false, configService);
 						}
 					} catch(Exception ex) {
 						logger.error("Error importing configuration", ex);

--- a/src/main/org/epics/archiverappliance/retrieval/bpl/GetPVMetaData.java
+++ b/src/main/org/epics/archiverappliance/retrieval/bpl/GetPVMetaData.java
@@ -63,10 +63,13 @@ public class GetPVMetaData implements BPLAction {
 			GetUrlContent.combineJSONObjects(retVal, typeInfoJSON);
 			String engineURL = configService.getAppliance(typeInfo.getApplianceIdentity()).getEngineURL() + "/getMetadata?pv=" + URLEncoder.encode(pvName, "UTF-8");
 			JSONObject engineMetaData = GetUrlContent.getURLContentAsJSONObject(engineURL);
+			// If we can't get info from the engine, return only what we have.
+			// For example the PV could just be paused and we also shouldn't fail completely
+			// if the engine is down.
 			if(engineMetaData != null) { 
 				GetUrlContent.combineJSONObjects(retVal, engineMetaData);
-				out.println(JSONValue.toJSONString(retVal));
 			}
+			out.println(JSONValue.toJSONString(retVal));
 		} catch(Exception ex) {
 			logger.error("Exception getting metadata typeinfo for pv " + pvName, ex);
 			resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Hi,
Here are many fixes and new features. Particularly notable are:
- ETL gating (only allow specifically marked data to pass to the next storage lifetime).
- More reliable store operation in the event of running out of disk space or crashes (e.g. handling incompletely written headers and samples).
- Generic engine infrastructure (allows implementing custom data sources not just CA/pvAccess).

I'm not really expecting you to merge all this at once of course. Many commits especially small fixes are independent and can just be cherry-picked.

A note regarding the generic data sources. This was implemented with the intent of being minimally invasive to the current design. It mostly just inserts branches at specific points in the code, and redirects the request to the generic code if the PV is found to be handler by a generic data source. PVs  of generic data sources must be prefixed with a name that identifies the generic data source, so that is is possible to determine the plugin (or default archiving) based only on the PV name.

I am happy to answer any questions about these changes.
