### PR TITLE
Adjust LD_LIBRARY_PATH to the right service

### DIFF
--- a/docs/samples/sampleStartup.sh
+++ b/docs/samples/sampleStartup.sh
@@ -59,10 +59,10 @@ function startTomcatAtLocation() {
     if [[ $ARCH == 'x86_64' || $ARCH == 'amd64' ]]
     then
       echo "Using 64 bit versions of libraries"
-      export LD_LIBRARY_PATH=${CATALINA_BASE}/webapps/engine/WEB-INF/lib/native/linux-x86_64:${LD_LIBRARY_PATH}
+      export LD_LIBRARY_PATH=${CATALINA_BASE}/webapps/mgmt/WEB-INF/lib/native/linux-x86_64:${LD_LIBRARY_PATH}
     else
       echo "Using 32 bit versions of libraries"
-      export LD_LIBRARY_PATH=${CATALINA_BASE}/webapps/engine/WEB-INF/lib/native/linux-x86:${LD_LIBRARY_PATH}
+      export LD_LIBRARY_PATH=${CATALINA_BASE}/webapps/mgmt/WEB-INF/lib/native/linux-x86:${LD_LIBRARY_PATH}
     fi
     
     pushd ${CATALINA_BASE}/logs


### PR DESCRIPTION
In sampleStartup.sh LD_LIBRARY_PATH gets set to an invalid path, as it
contains path to engine instead of mgmt.

**Warning**: I haven't run any test cases on this yet, I don't know ant nor the test cases very well. Please let me know in case I can assist by running some test command on this code to get it accepted.

> So in the end the path looks like:
> 
> ${ARCHAPPL_DEPLOY_DIR}/mgmt/webapps/**engine**/WEB-INF/lib/native/linux-x86...
> 
> But the real PATH here should be
> 
> ${ARCHAPPL_DEPLOY_DIR}/mgmt/webapps/**mgmt**/WEB-INF/lib/native/linux-x86...

The archiver still works without the LD_LIBRARY_PATH set correctly.

Fixes: #41