### PR TITLE
honour provided ca_how properly when processing ChannelArchiver requests

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/RetrievalState.java
+++ b/src/main/org/epics/archiverappliance/retrieval/RetrievalState.java
@@ -134,7 +134,7 @@ public class RetrievalState {
 				// We try to parse the how to make sure it is an int.
 				Integer.parseInt(caHowStr);
 			}
-			
+			howStr = caHowStr;
 		} catch(Exception ex) {
 			logger.warn("Exception parsing ca_how", ex);
 		}


### PR DESCRIPTION
Without the proposed assignment, the "ca_how" provided in the  request will never be used at all.