### PR TITLE
Fixing a bug where a year change is not caught when the postprocessors return raw events.

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/Optimized.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/Optimized.java
@@ -124,7 +124,7 @@ public class Optimized implements PostProcessor, PostProcessorWithConsolidatedEv
         if (numEvents > allEvents.size()) {
             return statisticsPostProcessor.getConsolidatedEventStream();
         } else {
-            return transformedRawEvents;
+            return new ArrayListCollectorEventStream(transformedRawEvents);
         }
     }
 

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
@@ -159,7 +159,7 @@ public class OptimizedWithLastSample implements PostProcessor, PostProcessorWith
         if (numEvents > allEvents.size()) {
             return customStatsConsolidatedEventStream();
         } else {
-            return transformedRawEvents;
+            return new ArrayListCollectorEventStream(transformedRawEvents);
         }
     }
     


### PR DESCRIPTION
We noticed an issue when plotting archived data that spans a year change. It occurs when the Optimized post-processor is used but in the condition where the number of events < number of bins requested. In this case no binning is needed so the raw events are returned in an `ArrayList`. This form of `ArrayList` has no method to identify or catch a year change. This means that instead of sending 2020-12-31... **2021**-01-01, it sends 2020-12-31... **2020**-01-01.

This PR fixes this issue in the `Optimized` and `OptimizedWithLastSample` postprocessors by wrapping the `ArrayList` in an `ArrayListCollectorEventStream` object , which contains an iterator and `next()` method to catch year changes and return this.