### PR TITLE
Retaining event field information when Optimized and OptimizedWithLastSample post-processors return non-binned events

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/Optimized.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/Optimized.java
@@ -13,12 +13,12 @@ import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
-import org.epics.archiverappliance.common.POJOEvent;
 import org.epics.archiverappliance.common.TimeSpan;
 import org.epics.archiverappliance.config.PVTypeInfo;
-import org.epics.archiverappliance.data.AlarmInfo;
 import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
 import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
+
+import edu.stanford.slac.archiverappliance.PB.data.DBR2PBTypeMapping;
 
 /**
  * 
@@ -174,11 +174,7 @@ public class Optimized implements PostProcessor, PostProcessorWithConsolidatedEv
                 } else {
                     transformedRawEvents = new ArrayListEventStream(allEvents.size(),allEvents.getDescription());
                     for (Event e : allEvents) {
-                        if (e instanceof AlarmInfo) {
-                            transformedRawEvents.add(new POJOEvent(e.getDBRType(),e.getEventTimeStamp(),e.getSampleValue(),((AlarmInfo)e).getStatus(),((AlarmInfo)e).getSeverity()));
-                        } else {
-                            transformedRawEvents.add(new POJOEvent(e.getDBRType(),e.getEventTimeStamp(),e.getSampleValue(),0,0));
-                        }
+                        transformedRawEvents.add(DBR2PBTypeMapping.getPBClassFor(e.getDBRType()).getSerializingConstructor().newInstance(e));
                     }
                     return transformedRawEvents;
                 }

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
@@ -339,12 +339,14 @@ public class OptimizedWithLastSample implements PostProcessor, PostProcessorWith
                     lastBinSaved = currentBin;
                 }
             }
-            if (lastBinSaved < lastBin) {
-                // Last bins have been skipped (had no events) so need to populate them
-                // with the last value from the last bin to have events
-                // Include the last bin (+1)
-                long nSkip = lastBin-lastBinSaved + 1;
-                populateSkippedBins(nSkip);  
+            if (lastBinSaved != null) {
+                if (lastBinSaved < lastBin) {
+                    // Last bins have been skipped (had no events) so need to populate them
+                    // with the last value from the last bin to have events
+                    // Include the last bin (+1)
+                    long nSkip = lastBin-lastBinSaved + 1;
+                    populateSkippedBins(nSkip);  
+                }
             }
             return new SummaryStatsCollectorEventStream(firstBin, lastBin, intervalSecs, srcDesc, consolidatedData,
                 inheritValuesFromPreviousBins, zeroOutEmptyBins(), true, 6);

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
@@ -329,13 +329,15 @@ public class OptimizedWithLastSample implements PostProcessor, PostProcessorWith
             // The last bin with events will not yet have been added so it needs to 
             // be added manually here in order to correct for the remaining bins with
             // no events.
-            if (currentBinCollector.haveEventsBeenAdded()) {
-                SummaryValue summaryValue;
-                summaryValue = new SummaryValue(
-                    ((SummaryStatsVectorCollector) currentBinCollector).getVectorValues(), currentMaxSeverity,
-                    currentConnectionChangedEvents);
-                consolidatedData.put(currentBin, summaryValue);
-                lastBinSaved = currentBin;
+            if (currentBinCollector != null) {
+                if (currentBinCollector.haveEventsBeenAdded()) {
+                    SummaryValue summaryValue;
+                    summaryValue = new SummaryValue(
+                        ((SummaryStatsVectorCollector) currentBinCollector).getVectorValues(), currentMaxSeverity,
+                        currentConnectionChangedEvents);
+                    consolidatedData.put(currentBin, summaryValue);
+                    lastBinSaved = currentBin;
+                }
             }
             if (lastBinSaved < lastBin) {
                 // Last bins have been skipped (had no events) so need to populate them

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/OptimizedWithLastSample.java
@@ -14,10 +14,8 @@ import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
-import org.epics.archiverappliance.common.POJOEvent;
 import org.epics.archiverappliance.common.TimeSpan;
 import org.epics.archiverappliance.config.PVTypeInfo;
-import org.epics.archiverappliance.data.AlarmInfo;
 import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
 import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 import org.epics.archiverappliance.common.TimeUtils;
@@ -25,6 +23,8 @@ import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.retrieval.postprocessors.SummaryStatsPostProcessor.SummaryValue;
 import org.epics.archiverappliance.data.DBRTimeEvent;
 import edu.stanford.slac.archiverappliance.PB.data.PBParseException;
+
+import edu.stanford.slac.archiverappliance.PB.data.DBR2PBTypeMapping;
 
 
 /**
@@ -232,11 +232,7 @@ public class OptimizedWithLastSample implements PostProcessor, PostProcessorWith
                 } else {
                     transformedRawEvents = new ArrayListEventStream(allEvents.size(),allEvents.getDescription());
                     for (Event e : allEvents) {
-                        if (e instanceof AlarmInfo) {
-                            transformedRawEvents.add(new POJOEvent(e.getDBRType(),e.getEventTimeStamp(),e.getSampleValue(),((AlarmInfo)e).getStatus(),((AlarmInfo)e).getSeverity()));
-                        } else {
-                            transformedRawEvents.add(new POJOEvent(e.getDBRType(),e.getEventTimeStamp(),e.getSampleValue(),0,0));
-                        }
+                        transformedRawEvents.add(DBR2PBTypeMapping.getPBClassFor(e.getDBRType()).getSerializingConstructor().newInstance(e));
                     }
                     return transformedRawEvents;
                 }


### PR DESCRIPTION
We wanted to be able to detect when a PV had become disconnected so that we could show it in the CS-Studio data browser. We followed the advice discussed in the issue https://github.com/slacmshankar/epicsarchiverap/issues/96 to get the fields '`cnxlostepsecs`' from the extra fields in the RAW response or if using the `Optimized` or `OptimizedWithLastSample` postprocessors the '`connectionChange`' field added by the AA.

However we found a special case where the information on a disconnect is completely lost. If the user requests `Optimized` or `OptimizedWithLastSample` data but the number of bins is larger than the number of events in a time period, then the raw events get transformed into a `POJOEvent` and returned. This type of event has no capacity to hold the extra fields information and so loses any information on the disconnect. 

This PR contains a fix for this by retaining the original event fields instead of creating a new `POJOEvent`. 

The PR also contains a minor bug fix in the `OptimizedWithLastSample.java` code to check 2 objects are not null before using them (bug found will testing the above).