### PR TITLE
Make the Mysql host configurable.

### DIFF
--- a/docs/samples/addMysqlConnPool.py
+++ b/docs/samples/addMysqlConnPool.py
@@ -8,17 +8,16 @@
 import sys
 import os
 import xml.dom.minidom
-import urlparse
 import shutil
 
 mysql_connection_string = os.getenv('MYSQL_CONNECTION_STRING')
 if not mysql_connection_string:
-	print 'The environment variable MYSQL_CONNECTION_STRING is not defined. Please define using export MYSQL_CONNECTION_STRING="--user=archappl --password=archappl --database=archappl"'
+	print('The environment variable MYSQL_CONNECTION_STRING is not defined. Please define using export MYSQL_CONNECTION_STRING="--user=archappl --password=archappl --database=archappl"')
 	sys.exit(1)
 
 tomcatHome = os.getenv("TOMCAT_HOME")
 if tomcatHome == None:
-	print "We determine the location of context.xml using the environment variable TOMCAT_HOME which does not seem to be set."
+	print("We determine the location of context.xml using the environment variable TOMCAT_HOME which does not seem to be set.")
 	sys.exit(1)
 
 connpoolparams = {}
@@ -29,27 +28,31 @@ for mysqlparam in mysql_connection_string.split():
 	connpoolparams[paramame] = paramval
 
 if 'user' not in connpoolparams:
-	print 'Cannot determine the user from ", mysql_connection_string, ". Please define like so "--user=archappl --password=archappl --database=archappl"'
+	print('Cannot determine the user from ", mysql_connection_string, ". Please define like so "--user=archappl --password=archappl --database=archappl"')
 	sys.exit(1)
 
 if 'password' not in connpoolparams:
-	print 'Cannot determine the user from ", mysql_connection_string, ". Please define like so "--user=archappl --password=archappl --database=archappl"'
+	print('Cannot determine the user from ", mysql_connection_string, ". Please define like so "--user=archappl --password=archappl --database=archappl"')
 	sys.exit(1)
 
 if 'database' not in connpoolparams:
-	print 'Cannot determine the user from ", mysql_connection_string, ". Please define like so "--user=archappl --password=archappl --database=archappl"'
+	print('Cannot determine the user from ", mysql_connection_string, ". Please define like so "--user=archappl --password=archappl --database=archappl"')
 	sys.exit(1)
 
+if 'host' not in connpoolparams:
+	connpoolparams['host'] = "localhost"
+	
 user=connpoolparams['user']
 pwd=connpoolparams['password']
 db=connpoolparams['database']
+host=connpoolparams['host']
 
 tomcatContextXML = tomcatHome + '/conf/context.xml'
 serverdom = xml.dom.minidom.parse(tomcatContextXML);
 resources = serverdom.getElementsByTagName('Resource')
 for resource in resources:
 	if resource.getAttribute('name') == 'jdbc/archappl':
-		print "Connection pool jdbc/archappl is already defined"
+		print("Connection pool jdbc/archappl is already defined")
 		sys.exit(0)
 
 
@@ -74,7 +77,7 @@ connpool.setAttribute('logAbandoned',"true")
 connpool.setAttribute('minEvictableIdleTimeMillis',"30000")
 connpool.setAttribute('jmxEnabled',"true")
 connpool.setAttribute('driverClassName',"com.mysql.jdbc.Driver")
-connpool.setAttribute('url',"jdbc:mysql://localhost:3306/" + connpoolparams['database'])
+connpool.setAttribute('url',"jdbc:mysql://"+connpoolparams['host']+":3306/" + connpoolparams['database'])
 connpool.setAttribute('username',connpoolparams['user'])
 connpool.setAttribute('password',connpoolparams['password'] )
 


### PR DESCRIPTION
Allows setting up a jdbc connection pool to a mysql server which might not be running on local host.

The default behaviour would still use localhost but with the following changes users can add `--host=remote.server` to the mysql connection string.