### PR TITLE
Persist with sqlite

### DIFF
--- a/src/main/org/epics/archiverappliance/config/persistence/archappl_sqlite.sql
+++ b/src/main/org/epics/archiverappliance/config/persistence/archappl_sqlite.sql
@@ -1,0 +1,43 @@
+CREATE TABLE PVTypeInfo ( 
+	pvName TEXT NOT NULL UNIQUE PRIMARY KEY,
+	typeInfoJSON TEXT NOT NULL,
+	last_modified TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER PVTypeInfo_update AFTER UPDATE ON PVTypeInfo FOR EACH ROW
+BEGIN
+	UPDATE PVTypeInfo SET last_modified = datetime('now') WHERE rowid==NEW.rowid;
+END;
+
+CREATE TABLE PVAliases ( 
+	pvName TEXT NOT NULL UNIQUE PRIMARY KEY,
+	realName TEXT NOT NULL,
+	last_modified TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER PVAliases_update AFTER UPDATE ON PVAliases FOR EACH ROW
+BEGIN
+	UPDATE PVAliases SET last_modified = datetime('now') WHERE rowid==NEW.rowid;
+END;
+
+CREATE TABLE ArchivePVRequests ( 
+	pvName TEXT NOT NULL PRIMARY KEY,
+	userParams TEXT NOT NULL,
+	last_modified TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER ArchivePVRequests_update AFTER UPDATE ON ArchivePVRequests FOR EACH ROW
+BEGIN
+	UPDATE ArchivePVRequests SET last_modified = datetime('now') WHERE rowid==NEW.rowid;
+END;
+
+CREATE TABLE ExternalDataServers ( 
+	serverid TEXT NOT NULL UNIQUE PRIMARY KEY,
+	serverinfo TEXT NOT NULL,
+	last_modified TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER ExternalDataServers_update AFTER UPDATE ON ExternalDataServers FOR EACH ROW
+BEGIN
+	UPDATE ExternalDataServers SET last_modified = datetime('now') WHERE rowid==NEW.rowid;
+END;


### PR DESCRIPTION
Persistence using sqlite as an alternative to mysql/mariadb.  The only differences are the syntax of a non-standard `UPSERT` operation, and the date/time format of the `last_modified` column.

Needs https://github.com/xerial/sqlite-jdbc in the class path.

In `context.xml`

```xml
<Resource name="jdbc/archappl"
        auth="Container"
        type="javax.sql.DataSource"
        driverClassName="org.sqlite.JDBC"
        url="jdbc:sqlite:/path/to/appl.db"
        factory="org.apache.tomcat.dbcp.dbcp2.BasicDataSourceFactory"
 />
```

Note that sqlite requires both the DB file, and the containing directory, to be writable.

Initialize with

```sh
sqlite3 /path/to/appl.db -init /path/to/archappl_sqlite.sql
```