### PR TITLE
Simplify retrieval of retired PVs

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/DataRetrievalServlet.java
+++ b/src/main/org/epics/archiverappliance/retrieval/DataRetrievalServlet.java
@@ -89,6 +89,10 @@ import org.epics.archiverappliance.retrieval.workers.CurrentThreadExecutorServic
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
+import org.python.core.PyDictionary;
+import org.python.core.PyList;
+import org.python.core.PySystemState;
+import org.python.util.PythonInterpreter;
 
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo.Builder;
@@ -104,6 +108,8 @@ import edu.stanford.slac.archiverappliance.PB.utils.LineEscaper;
 public class DataRetrievalServlet  extends HttpServlet {
 	public static final int SERIAL_PARALLEL_MEMORY_CUTOFF_MB = 60;
 	private static final String ARCH_APPL_PING_PV = "ArchApplPingPV";
+	private static final String SEARCH_STORE_FOR_RETIRED_PV_STR = 
+			"org.epics.archiverappliance.retrieval.SearchStoreForRetiredPvs";
 	private static Logger logger = Logger.getLogger(DataRetrievalServlet.class.getName());
 	static class MimeMappingInfo {
 		Class<? extends MimeResponse> mimeresponseClass;
@@ -360,9 +366,14 @@ public class DataRetrievalServlet  extends HttpServlet {
 		}
 			
 		if(typeInfo == null) {
+			// Check to see if property prompting a further search of the datastore is set. 
+			// Default to false if property does not exist.
+			String searchStoreForRetiredPvsStr = configService.getInstallationProperties()
+					.getProperty(SEARCH_STORE_FOR_RETIRED_PV_STR, "false");
+			boolean searchStoreForNullTypeInfo = Boolean.parseBoolean(searchStoreForRetiredPvsStr);
 			if(retiredPVTemplate != null) {
 				PVTypeInfo templateTypeInfo = PVNames.determineAppropriatePVTypeInfo(retiredPVTemplate, configService);
-				if(templateTypeInfo != null) { 
+				if(templateTypeInfo != null) {
 					typeInfo = new PVTypeInfo(pvName, templateTypeInfo);
 					typeInfo.setPaused(true);
 					typeInfo.setApplianceIdentity(configService.getMyApplianceInfo().getIdentity());
@@ -370,6 +381,47 @@ public class DataRetrievalServlet  extends HttpServlet {
 					typeInfo.setSamplingMethod(SamplingMethod.DONT_ARCHIVE);
 					logger.debug("Using a template PV for " + pvName + " Need to determine the actual DBR type.");
 					setActualDBRTypeFromData(pvName, typeInfo, configService);
+				}
+			} else if (searchStoreForNullTypeInfo) {
+				// Create Python interpreter to access policies.py methods
+				PythonInterpreter interp = new PythonInterpreter(null, new PySystemState());
+
+				// Load the policies.py into the interpreter.
+				try (InputStream is = configService.getPolicyText()) {
+				    interp.execfile(is);
+				}
+
+				// Call policies.py determinePolicy() method
+				PyDictionary pvInfoDict = new PyDictionary();
+				pvInfoDict.put("pvName", pvName);
+				pvInfoDict.put("policyName", "");
+				pvInfoDict.put("eventRate", 1.0);
+				interp.set("pvInfo", pvInfoDict);
+				interp.exec("pvPolicy = determinePolicy(pvInfo)");
+				PyDictionary policy = (PyDictionary) interp.get("pvPolicy");
+
+				LinkedList<String> dataStores = new LinkedList<String>();
+				for (Object dataStore : (PyList) policy.get("dataStores")) {
+				    dataStores.add((String) dataStore);
+				}
+				interp.cleanup();
+
+				// Create new PVTypeInfo with pvName and the default dataStores
+				// obtained from the policies.py definitions
+				typeInfo = new PVTypeInfo();
+				typeInfo.setPvName(pvName);
+				typeInfo.setPaused(true);
+				typeInfo.setApplianceIdentity(configService.getMyApplianceInfo().getIdentity());
+				// Somehow tell the code downstream that this is a fake
+				// typeInfo.
+				typeInfo.setSamplingMethod(SamplingMethod.DONT_ARCHIVE);
+				typeInfo.setDataStores(dataStores.toArray(new String[dataStores.size()]));
+				boolean foundRetiredPV = setActualDBRTypeFromData(pvName, typeInfo, configService);
+				
+				// If the PV does not exist in the dataStores at all then
+				// set the typeInfo back to null so it will return no data
+				if (!foundRetiredPV) {
+				    typeInfo = null;
 				}
 			}
 		}
@@ -766,6 +818,11 @@ public class DataRetrievalServlet  extends HttpServlet {
 		
 		for (int i = 0; i < pvNames.size(); i++) {
 			if(typeInfos.get(i) == null) {
+				// Check to see if property prompting a further search of the datastore is set. 
+				// Default to false if property does not exist.
+				String searchStoreForRetiredPvsStr = configService.getInstallationProperties()
+						.getProperty(SEARCH_STORE_FOR_RETIRED_PV_STR, "false");
+				boolean searchStoreForNullTypeInfo = Boolean.parseBoolean(searchStoreForRetiredPvsStr);
 				if(retiredPVTemplate != null) {
 					PVTypeInfo templateTypeInfo = PVNames.determineAppropriatePVTypeInfo(retiredPVTemplate, configService);
 					if(templateTypeInfo != null) { 
@@ -776,6 +833,47 @@ public class DataRetrievalServlet  extends HttpServlet {
 						typeInfos.get(i).setSamplingMethod(SamplingMethod.DONT_ARCHIVE);
 						logger.debug("Using a template PV for " + pvNames.get(i) + " Need to determine the actual DBR type.");
 						setActualDBRTypeFromData(pvNames.get(i), typeInfos.get(i), configService);
+					}
+				} else if (searchStoreForNullTypeInfo) {
+					// Create Python interpreter to access policies.py methods
+					PythonInterpreter interp = new PythonInterpreter(null, new PySystemState());
+
+					// Load the policies.py into the interpreter.
+					try (InputStream is = configService.getPolicyText()) {
+					    interp.execfile(is);
+					}
+
+					// Call policies.py determinePolicy() method
+					PyDictionary pvInfoDict = new PyDictionary();
+					pvInfoDict.put("pvName", pvNames.get(i));
+					pvInfoDict.put("policyName", "");
+					pvInfoDict.put("eventRate", 1.0);
+					interp.set("pvInfo", pvInfoDict);
+					interp.exec("pvPolicy = determinePolicy(pvInfo)");
+					PyDictionary policy = (PyDictionary) interp.get("pvPolicy");
+
+					LinkedList<String> dataStores = new LinkedList<String>();
+					for (Object dataStore : (PyList) policy.get("dataStores")) {
+					    dataStores.add((String) dataStore);
+					}
+					interp.cleanup();
+
+					// Create new PVTypeInfo with pvName and the default dataStores
+					// obtained from the policies.py definitions
+					typeInfos.set(i, new PVTypeInfo());
+					typeInfos.get(i).setPvName(pvNames.get(i));
+					typeInfos.get(i).setPaused(true);
+					typeInfos.get(i).setApplianceIdentity(configService.getMyApplianceInfo().getIdentity());
+					// Somehow tell the code downstream that this is a fake
+					// typeInfo.
+					typeInfos.get(i).setSamplingMethod(SamplingMethod.DONT_ARCHIVE);
+					typeInfos.get(i).setDataStores(dataStores.toArray(new String[dataStores.size()]));
+					boolean foundRetiredPV = setActualDBRTypeFromData(pvNames.get(i), typeInfos.get(i), configService);
+					
+					// If the PV does not exist in the dataStores at all then
+					// set the typeInfo back to null so it will return no data
+					if (!foundRetiredPV) {
+					    typeInfos.set(i, null);
 					}
 				}
 			}

--- a/src/sitespecific/tests/classpathfiles/archappl.properties
+++ b/src/sitespecific/tests/classpathfiles/archappl.properties
@@ -27,6 +27,12 @@ org.epics.archiverappliance.config.PVTypeInfo.sampleBufferCapacityAdjustment = 1
 org.epics.archiverappliance.retrieval.DefaultUseReducedPostProcessor=org.epics.archiverappliance.retrieval.postprocessors.TwoWeekRaw
 
 
+# If a PV used to be archived by the appliance but has since been retired, data does not get returned from the request even though data might exist in the 
+# datastores. Setting this option to 'true' means that if a request is received for a PV that is not currently being archived (i.e. the PVTypeInfo is null),
+# it will automatically then run a search in the datastores to see if there is any data available for this PV within the timeframe and return it.
+# org.epics.archiverappliance.retrieval.SearchStoreForRetiredPvs=true
+
+
 # This propery has been deprecated as it can easily lead to data loss.
 # The maximum number of datastores/stages/lifetimeids in this installation.
 # Specifically, this returns the maximum length of the datastores element across all  PVTypeInfo's in this installation. 
@@ -106,3 +112,6 @@ org.epics.archiverappliance.engine.util.EngineContext.disconnectCheckTimeoutInMi
 # By default, this is set to a day. So, if the archiver cannot connect to the PV in a day, it will give up and abort.
 # To turn this off, set this to -1.
 # org.epics.archiverappliance.mgmt.MgmtRuntimeState.abortArchiveRequestInMins = 1440
+
+
+


### PR DESCRIPTION
At present it is possible to retrieve data for a PV which is no longer achived, a "retired" PV, by specifying a template PV whose `PVTypeInfo` can be used instead. This is the `retiredPVTemplate` parameter. There are some drawbacks to this approach:

- It is not always straightforward to determine a suitable Template PV
- There is no implementation in the CS Studio databrowser to provide this parameter, and it is an extra complication for other clients

We have a proposal for a simpler mechanism. We observed that the only information used from the `PVTypeInfo` is the location of the data stores to be searched (the type itself comes from the PB files). The location of the data stores can be found instead from the `policies.py` file. The proposed change is:

- If a PV is requested for retrieval, but its PVTypeInfo is not found (ie it is not currently being archived), then run `determinePolicy` from `policies.py` to get the locations of the data stores.
- Then use these locations to search for data, and return it if found

This means that the client does not need to specify any extra parameters in order to retrieve data for a retired PV. This has been tested in our local test server and has the desired effect. Retired PV data can be retrieved from CS-Studio without any changes in the client.

This behaviour aims to be transparent to those not using it - 

- If RetiredPVTemplate is specified then this will be used instead;
- The behavious is enabled by a preference

We welcome feedback on this approach. In particular, others may have different uses of their `policies.py` file which may need to be accounted for.
