### PR TITLE
Fix for OptimizedPostProcessorTest failing 

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/ArrayListCollectorEventStream.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/ArrayListCollectorEventStream.java
@@ -8,7 +8,6 @@ import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
 import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
-import org.epics.archiverappliance.retrieval.ChangeInYearsException;
 import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 import org.epics.archiverappliance.retrieval.RemotableOverRaw;
 
@@ -65,11 +64,9 @@ public class ArrayListCollectorEventStream implements EventStream, RemotableOver
 			Event next = sourceStream.get(currentIndex);
 			short eventYear = TimeUtils.computeYearForEpochSeconds(next.getEpochSeconds());
 			if(eventYear != currentYear) { 
-				logger.info("Detected a change in years eventYear " + eventYear + " and currentYear is " + eventYear);
+				logger.warn("Detected a change in years eventYear " + eventYear + " and currentYear is " + eventYear);
 				ArrayListCollectorEventStream.this.desc.setYear(eventYear);
-				short tempCurrentYear = currentYear;
 				currentYear = eventYear;
-				throw new ChangeInYearsException(tempCurrentYear, eventYear);
 			}
 			currentIndex++;
 			return next;


### PR DESCRIPTION
Test case testPPLessPointsThanRequested is failing. fixes #146

This is due to the Optimized.java Post Processor returning a ArrayListCollectorEventStream which throws a ChangeInYearsException from the first iteration.

Simply remove the ChangeInYearsException for a warning log instead. That way problems can still be detected without dropping the whole process.