### PR TITLE
Add a setting to make pvAccess or Channel Access the default protocol…

### DIFF
--- a/src/main/org/epics/archiverappliance/config/PVNames.java
+++ b/src/main/org/epics/archiverappliance/config/PVNames.java
@@ -17,6 +17,12 @@ public class PVNames {
 	 * This syntax should be consistent with CSS. 
 	 */
 	public static final String V4_PREFIX = "pva://";
+
+	/**
+	 * When you intend to connect to the PV's using Channel Access, use this string as a prefix in the UI/archivePV BPL. For example, ca://double01
+	 * This syntax should be consistent with CSS.
+	 */
+	public static final String V3_PREFIX = "ca://";
 	
 	/**
 	 * Remove the .VAL, .HIHI etc portion of a pvName and return the plain pvName
@@ -332,17 +338,31 @@ public class PVNames {
 	}
 
 
-	/**
-	 * Does this pvName imply a connection using PVAccess?
-	 * @param pvName  The name of PV.
-	 * @return boolean True or False
-	 */
-	public static boolean isEPICSV4PVName(String pvName) { 
-		if(pvName == null || pvName.isEmpty()) return false;
-		return pvName.startsWith(V4_PREFIX);
+	public enum EPICSVersion {
+		V3,
+		V4,
+		DEFAULT
 	}
-	
-	
+
+	/**
+	 * What type of name is the pv.
+	 * return EPICSVersion.V3 if starts with ca://
+	 * return EPICSVersion.V4 if starts with pva://
+	 * returns EPICSVersion.DEFAULT otherwise.
+	 *
+	 * @param pvName  The name of PV.
+	 * @return EPICSVersion
+	 */
+	public static EPICSVersion pvNameVersion(String pvName) {
+		if(pvName == null || pvName.isEmpty()) return EPICSVersion.DEFAULT;
+		if (pvName.startsWith(V4_PREFIX))
+			return EPICSVersion.V4;
+		if (pvName.startsWith(V3_PREFIX))
+			return EPICSVersion.V3;
+		return EPICSVersion.DEFAULT;
+	}
+
+
 	/**
 	 * Remove the pva:// prefix from the PV name if present.
 	 * @param pvName The name of PV.
@@ -350,8 +370,11 @@ public class PVNames {
 	 */
 	public static String stripPrefixFromName(String pvName) { 
 		if(pvName == null || pvName.isEmpty()) return pvName;
-		if(pvName.startsWith(V4_PREFIX)) { 
+		if(pvName.startsWith(V4_PREFIX)) {
 			return pvName.replace(V4_PREFIX, "");
+		}
+		if(pvName.startsWith(V3_PREFIX)) {
+			return pvName.replace(V3_PREFIX, "");
 		}
 		
 		return pvName;

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
@@ -172,6 +172,29 @@ public class ArchivePVAction implements BPLAction {
 
 
 	/**
+	 * Does this pvName imply a connection using PVAccess?
+	 * @param pvName  The name of PV.
+	 * @param defaultProtocol  The defaultProtocol see org.epics.archiverappliance.mgmt.config.defaultAccessProtocol
+	 *                         default is CA
+	 * @return boolean True or False
+	 */
+	public static boolean usePVAccess(String pvName, String defaultProtocol) {
+		PVNames.EPICSVersion version = PVNames.pvNameVersion(pvName);
+		switch (version) {
+			case DEFAULT -> {
+				return defaultProtocol.equals("PVA");
+			}
+			case V3 -> {
+				return false;
+			}
+			case V4 -> {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * This is the main method for adding PVs into the archiver. All other entry points should eventually call this method.
 	 * @param out PrintWriter
 	 * @param pvName The name of PV.
@@ -186,7 +209,11 @@ public class ArchivePVAction implements BPLAction {
 	 * @param fieldsArchivedAsPartOfStream  &emsp;
 	 * @throws IOException  &emsp;
 	 */
-	public static void archivePV(PrintWriter out, String pvName, boolean overridePolicyParams, SamplingMethod overriddenSamplingMethod, float overRiddenSamplingPeriod, String controllingPV, String policyName, String alias, boolean skipCapacityPlanning, ConfigService configService, List<String> fieldsArchivedAsPartOfStream) throws IOException {
+	public static void archivePV(PrintWriter out, String pvName, boolean overridePolicyParams,
+	                             SamplingMethod overriddenSamplingMethod, float overRiddenSamplingPeriod,
+	                             String controllingPV, String policyName, String alias, boolean skipCapacityPlanning,
+	                             ConfigService configService, List<String> fieldsArchivedAsPartOfStream)
+			throws IOException {
 		String fieldName = PVNames.getFieldName(pvName);
 		boolean isStandardFieldName = false;
 
@@ -210,8 +237,11 @@ public class ArchivePVAction implements BPLAction {
 			throw new IOException(msg);
 		}
 
-		// Check for V4 syntax; here's where we lose the prefix
-		boolean usePVAccess = PVNames.isEPICSV4PVName(pvName);
+		// Check for V4 syntax or default protocol; here's where we lose the prefix
+		String defaultProtocol = configService.getInstallationProperties()
+				.getProperty("org.epics.archiverappliance.mgmt.config.defaultAccessProtocol", "CA");
+
+		boolean usePVAccess = usePVAccess(pvName, defaultProtocol);
 		if(usePVAccess) {
 			pvName = PVNames.stripPrefixFromName(pvName);
 			logger.debug("Removing the V4 prefix from the pvName for " + pvName);

--- a/src/sitespecific/slacdev/classpathfiles/archappl.properties
+++ b/src/sitespecific/slacdev/classpathfiles/archappl.properties
@@ -117,3 +117,7 @@ org.epics.archiverappliance.engine.util.EngineContext.disconnectCheckTimeoutInMi
 # org.epics.archiverappliance.engine.maximum_disconnected_channel_percentage_before_starting_metachannels = 5.0
 # org.epics.archiverappliance.engine.metachannels_to_start_at_a_time = 10000
 
+# Choose whether to use pvAccess or Channel Access by default
+# Options are CA for Channel Access or PVA for pvAccess
+# Default is CA
+# org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.defaultAccessProtocol = PVA

--- a/src/sitespecific/tests/classpathfiles/archappl.properties
+++ b/src/sitespecific/tests/classpathfiles/archappl.properties
@@ -117,3 +117,7 @@ org.epics.archiverappliance.engine.util.EngineContext.disconnectCheckTimeoutInMi
 # org.epics.archiverappliance.engine.maximum_disconnected_channel_percentage_before_starting_metachannels = 5.0
 # org.epics.archiverappliance.engine.metachannels_to_start_at_a_time = 10000
 
+# Choose whether to use pvAccess or Channel Access by default
+# Options are CA for Channel Access or PVA for pvAccess
+# Default is CA
+# org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.defaultAccessProtocol = PVA


### PR DESCRIPTION
… when adding new pvs.

Also adds the ability to override using pvAccess by default using ca:// as an prefix when adding a pv.