### PR TITLE
Adds the multi platform provider of web drivers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     testImplementation("org.seleniumhq.selenium:selenium-api:4.7.0")
     testImplementation("org.seleniumhq.selenium:selenium-firefox-driver:4.7.0")
     testImplementation("org.seleniumhq.selenium:selenium-support:4.7.0")
+    testImplementation("io.github.bonigarcia:webdrivermanager:5.3.2")
     implementation("org.apache.tomcat:tomcat-servlet-api:7.0.12")// Only needed for tests, but inbuilt to main)
     implementation("org.epics:jca:2.4.7")
     implementation("org.epics:epics-ntypes:0.3.7")
@@ -108,7 +109,16 @@ tasks.register("cleanWars", Delete) {
     delete file("${warDir}/archappl_v${version}.tar.gz")
     delete file("RELEASE_NOTES")
 }
+Collection getListOfFolders(String dir, String pattern) {
+    file(dir).listFiles({file -> !file.isFile() && file.name ==~ pattern} as FileFilter)
+}
 
+tasks.register("cleanTestData", Delete) {
+    group = "Clean"
+    description = "Remove any integration test folders created, and the staging directory"
+    delete getListOfFolders("./", /tomcat_*/)
+}
+clean.dependsOn("cleanTestData")
 clean.dependsOn "cleanWars"
 
 tasks.register("generateBPLActionsMappings", JavaExec) {
@@ -219,6 +229,11 @@ tasks.withType(War).configureEach {
     dependsOn "stage"
     from("${stageDir}/org/epics/archiverappliance/staticcontent") {
         into "ui/comm"
+    }
+    if (archapplsite == "tests") {
+        from("log4j.properties") {
+            into "WEB-INF/classes"
+        }
     }
     from("src/sitespecific/${archapplsite}/classpathfiles") {
         into "WEB-INF/classes"
@@ -392,6 +407,12 @@ tasks.register("flakyTests", Test) {
     }
 }
 
+tasks.register("shutdownAllTomcats", Exec) {
+    group = "test"
+    description "task to shut down all tomcats after running integration tests," +
+            " if they didn't shut down correctly."
+    commandLine "pkill", "-9", "-f", "tomcat"
+}
 tasks.register("integrationTests", Test) {
     group = "Test"
     description = "Run the integration tests, ones that require a tomcat installation."

--- a/src/test/org/epics/archiverappliance/engine/test/CnxLostTest.java
+++ b/src/test/org/epics/archiverappliance/engine/test/CnxLostTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -25,6 +26,7 @@ import org.epics.archiverappliance.retrieval.client.GenMsgIterator;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrieval;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -44,6 +46,11 @@ public class CnxLostTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/AddRemoveAliasTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/AddRemoveAliasTest.java
@@ -20,12 +20,15 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
 
 /**
  * Check addAlias and removeAlias functionality.
@@ -40,6 +43,11 @@ public class AddRemoveAliasTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/ArchiveAliasedPVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchiveAliasedPVTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.sql.Timestamp;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
@@ -17,6 +18,7 @@ import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -35,6 +37,11 @@ public class ArchiveAliasedPVTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsNotInStreamTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsNotInStreamTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
@@ -20,6 +21,7 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -80,6 +82,10 @@ public class ArchiveFieldsNotInStreamTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		System.getProperties().put("ARCHAPPL_POLICIES", System.getProperty("user.dir") + "/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsNotInStream.py");

--- a/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsWorkflowTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsWorkflowTest.java
@@ -2,6 +2,7 @@ package org.epics.archiverappliance.mgmt;
 
 import static org.junit.Assert.assertTrue;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -9,6 +10,7 @@ import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -29,6 +31,10 @@ public class ArchiveFieldsWorkflowTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();

--- a/src/test/org/epics/archiverappliance/mgmt/ArchivePVClusterTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchivePVClusterTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -15,6 +16,7 @@ import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -35,6 +37,10 @@ public class ArchivePVClusterTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		if(persistenceFolder.exists()) {

--- a/src/test/org/epics/archiverappliance/mgmt/ArchivePVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchivePVTest.java
@@ -2,6 +2,7 @@ package org.epics.archiverappliance.mgmt;
 
 import static org.junit.Assert.assertTrue;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -9,6 +10,7 @@ import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -28,6 +30,10 @@ public class ArchivePVTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();

--- a/src/test/org/epics/archiverappliance/mgmt/ArchiveWithSamplingPeriodPVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchiveWithSamplingPeriodPVTest.java
@@ -2,6 +2,7 @@ package org.epics.archiverappliance.mgmt;
 
 import static org.junit.Assert.assertTrue;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -9,6 +10,7 @@ import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -23,6 +25,10 @@ public class ArchiveWithSamplingPeriodPVTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();

--- a/src/test/org/epics/archiverappliance/mgmt/ChangeArchivalParamsTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ChangeArchivalParamsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -11,6 +12,7 @@ import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -25,6 +27,10 @@ public class ChangeArchivalParamsTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();

--- a/src/test/org/epics/archiverappliance/mgmt/InactiveClusterMemberArchivePVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/InactiveClusterMemberArchivePVTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -17,6 +18,7 @@ import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -47,6 +49,10 @@ public class InactiveClusterMemberArchivePVTest {
 	WebDriver driver;
 	SIOCSetup siocSetup = new SIOCSetup();
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/ModifyMetaFieldsTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ModifyMetaFieldsTest.java
@@ -8,6 +8,7 @@ import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -21,6 +22,7 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -41,6 +43,10 @@ public class ModifyMetaFieldsTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		if(persistenceFolder.exists()) {

--- a/src/test/org/epics/archiverappliance/mgmt/RenamePVBPLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/RenamePVBPLTest.java
@@ -8,6 +8,7 @@ import java.net.URLEncoder;
 import java.sql.Timestamp;
 import java.util.HashMap;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -32,6 +33,7 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -59,7 +61,11 @@ public class RenamePVBPLTest {
 	private File ltsFolderForNewPVName = new File(System.getenv("ARCHAPPL_LONG_TERM_FOLDER") + "/NewName_UnitTestNoNamingConvention");
 	StoragePlugin storageplugin;
 	private ConfigServiceForTests configService;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		if(ltsFolder.exists()) { 

--- a/src/test/org/epics/archiverappliance/mgmt/ScanSamplingMethodTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ScanSamplingMethodTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.sql.Timestamp;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
@@ -19,6 +20,7 @@ import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStrea
 import org.epics.archiverappliance.retrieval.client.RetrievalEventProcessor;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -44,6 +46,10 @@ public class ScanSamplingMethodTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 	@Before
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();

--- a/src/test/org/epics/archiverappliance/mgmt/VALNoVALTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/VALNoVALTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
@@ -19,6 +20,7 @@ import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -44,6 +46,10 @@ public class VALNoVALTest {
 	String folderMTS = ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "reshardMTS";
 	String folderLTS = ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "reshardLTS";
 
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/appxml/FQDNApplianceXMLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/appxml/FQDNApplianceXMLTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -14,6 +15,7 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -32,7 +34,12 @@ public class FQDNApplianceXMLTest {
 	File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ApplianceXMLTest");
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	WebDriver driver;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		if(testFolder.exists()) { 

--- a/src/test/org/epics/archiverappliance/mgmt/appxml/IPApplianceXMLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/appxml/IPApplianceXMLTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -14,6 +15,7 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -32,7 +34,12 @@ public class IPApplianceXMLTest {
 	File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ApplianceXMLTest");
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	WebDriver driver;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		if(testFolder.exists()) { 

--- a/src/test/org/epics/archiverappliance/mgmt/appxml/LocalhostApplianceXMLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/appxml/LocalhostApplianceXMLTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.PrintWriter;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -13,6 +14,7 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -31,7 +33,12 @@ public class LocalhostApplianceXMLTest {
 	File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ApplianceXMLTest");
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	WebDriver driver;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		if(testFolder.exists()) { 

--- a/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVAfterRestartTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVAfterRestartTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -18,6 +19,7 @@ import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
 import org.epics.archiverappliance.mgmt.policy.PolicyConfig.SamplingMethod;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -38,6 +40,11 @@ public class DeletePVAfterRestartTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -16,6 +17,7 @@ import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -36,6 +38,11 @@ public class DeletePVTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/pauseresume/ResumePVAfterRestartTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/pauseresume/ResumePVAfterRestartTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -19,6 +20,7 @@ import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
 import org.epics.archiverappliance.mgmt.policy.PolicyConfig.SamplingMethod;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -39,6 +41,11 @@ public class ResumePVAfterRestartTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/reshard/BasicReshardingTest.java
+++ b/src/test/org/epics/archiverappliance/reshard/BasicReshardingTest.java
@@ -9,6 +9,7 @@ import java.net.URLEncoder;
 import java.sql.Timestamp;
 import java.util.List;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
@@ -35,6 +36,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -71,6 +73,11 @@ public class BasicReshardingTest {
 	String folderSTS = ConfigServiceForTests.getDefaultShortTermFolder() + File.separator + "reshardSTS";
 	String folderMTS = ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "reshardMTS";
 	String folderLTS = ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "reshardLTS";
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/retrieval/client/Mean600Test.java
+++ b/src/test/org/epics/archiverappliance/retrieval/client/Mean600Test.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.HashMap;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -25,6 +26,7 @@ import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -52,7 +54,12 @@ public class Mean600Test {
 	private File ltsFolder = new File(System.getenv("ARCHAPPL_LONG_TERM_FOLDER") + "/UnitTestNoNamingConvention");
 	StoragePlugin storageplugin;
 	private ConfigServiceForTests configService;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		configService = new ConfigServiceForTests(new File("./bin"));

--- a/src/test/org/epics/archiverappliance/retrieval/client/PostProcessorWithPBErrorDailyTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/client/PostProcessorWithPBErrorDailyTest.java
@@ -13,6 +13,7 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Random;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -32,6 +33,7 @@ import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -67,7 +69,12 @@ public class PostProcessorWithPBErrorDailyTest {
 	StoragePlugin storageplugin;
 	private ConfigServiceForTests configService;
 	private short dataGeneratedForYears = 5;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		configService = new ConfigServiceForTests(new File("./bin"));

--- a/src/test/org/epics/archiverappliance/retrieval/client/PostProcessorWithPBErrorTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/client/PostProcessorWithPBErrorTest.java
@@ -13,6 +13,7 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Random;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
@@ -32,6 +33,7 @@ import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -63,7 +65,12 @@ public class PostProcessorWithPBErrorTest {
 	StoragePlugin storageplugin;
 	private ConfigServiceForTests configService;
 	private short dataGeneratedForYears = 5;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		configService = new ConfigServiceForTests(new File("./bin"));

--- a/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterAliasSpanApplianceTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterAliasSpanApplianceTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.sql.Timestamp;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
@@ -24,6 +25,7 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -44,6 +46,11 @@ public class ClusterAliasSpanApplianceTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterAliasTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterAliasTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
@@ -21,6 +22,7 @@ import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -41,6 +43,11 @@ public class ClusterAliasTest {
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/retrieval/extrafields/EGUChangeTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/extrafields/EGUChangeTest.java
@@ -7,6 +7,7 @@ import java.net.URLEncoder;
 import java.sql.Timestamp;
 import java.util.HashMap;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.IntegrationTests;
 import org.epics.archiverappliance.LocalEpicsTests;
@@ -22,6 +23,7 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -45,6 +47,11 @@ public class EGUChangeTest {
 	SIOCSetup siocSetup = new SIOCSetup();
 	WebDriver driver;
 	private String pvName = "UnitTestNoNamingConvention:sine";
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
 
 	@Before
 	public void setUp() throws Exception {

--- a/src/test/org/epics/archiverappliance/retrieval/postprocessor/VariousPostProcessorTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/postprocessor/VariousPostProcessorTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.epics.archiverappliance.Event;
@@ -20,6 +21,7 @@ import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
@@ -48,7 +50,12 @@ public class VariousPostProcessorTest {
 	double expectedStd = 1.7370;
 	double expectedJitter = 1.5851;
 	double expectedVariance = 3.0172;
-	
+
+	@BeforeClass
+	public static void setupClass() {
+		WebDriverManager.firefoxdriver().setup();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		FileUtils.deleteDirectory(new File(ConfigServiceForTests.getDefaultShortTermFolder() + File.separator + "UnitTestNoNamingConvention"));


### PR DESCRIPTION
Adds web_driver_manager which downloads webdrivers for the specific platform a test is being run on.
Also adds some helper tasks to the gradle build script:

- clean now also cleans away any integration test folders
- log4j settings are transfered into the wars when running tests
- If testing didn't shut cleanly a task to shutdown tomcats is created (UNIX specific)