### PR TITLE
CSSTUDIO-2134 Two bugfixes to `SummaryStatsPostProcessor` and one bugfix and one improvement to `Optimized`.

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/Optimized.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/Optimized.java
@@ -99,7 +99,8 @@ public class Optimized implements PostProcessor, PostProcessorWithConsolidatedEv
     
     @Override
     public long estimateMemoryConsumption(String pvName, PVTypeInfo typeInfo, Instant start, Instant end, HttpServletRequest req) {
-        int intervalSecs = (int) ((end.toEpochMilli() - start.toEpochMilli()) / (1000 * numberOfPoints));
+        long intervalSecsLong = ((end.getEpochSecond() - start.getEpochSecond()) / ((long) numberOfPoints));
+        int intervalSecs = intervalSecsLong > Integer.MAX_VALUE ? Integer.MAX_VALUE : Math.max(1, (int) intervalSecsLong);
         try {
             statisticsPostProcessor.initialize(getIdentity() + "_" + Integer.toString(intervalSecs),pvName);
         } catch (IOException e) {

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
@@ -45,7 +45,11 @@ public abstract class SummaryStatsPostProcessor implements PostProcessor, PostPr
 	public int getElementCount() {
 	    return 1;
 	}
-	
+
+
+	private Instant start;
+	private Instant end;
+
 	private static Logger logger = LogManager.getLogger(SummaryStatsPostProcessor.class.getName());
 	int intervalSecs = PostProcessors.DEFAULT_SUMMARIZING_INTERVAL;
     private Instant previousEventTimestamp = Instant.ofEpochMilli(1);
@@ -123,6 +127,8 @@ public abstract class SummaryStatsPostProcessor implements PostProcessor, PostPr
 
 	@Override
     public long estimateMemoryConsumption(String pvName, PVTypeInfo typeInfo, Instant start, Instant end, HttpServletRequest req) {
+		this.start = start;
+		this.end = end;
 		firstBin = TimeUtils.convertToEpochSeconds(start)/intervalSecs;
 		lastBin = TimeUtils.convertToEpochSeconds(end)/intervalSecs;
 		logger.debug("Expecting " + lastBin + " - " + firstBin + " values " + (lastBin+2 - firstBin)); // Add 2 for the first and last bins..
@@ -143,6 +149,7 @@ public abstract class SummaryStatsPostProcessor implements PostProcessor, PostPr
 				try(EventStream strm = callable.call()) {
 					// If we cache the mean/sigma etc, then we should add something to the desc telling us that this is cached data and then we can replace the stat value for that bin?
 					if(srcDesc == null) srcDesc = (RemotableEventStreamDesc) strm.getDescription();
+					boolean shouldAddLastSampleBeforeStart = true;
 					for(Event e : strm) {
 						try { 
 							DBRTimeEvent dbrTimeEvent = (DBRTimeEvent) e;
@@ -156,54 +163,56 @@ public abstract class SummaryStatsPostProcessor implements PostProcessor, PostPr
 								}
 								continue;
 							}
+							Instant eventInstant = dbrTimeEvent.getEventTimeStamp();
 							long binNumber = epochSeconds/intervalSecs;
-							if(binNumber >= firstBin && binNumber <= lastBin) {
-								// We only add bins for the specified time frame. 
-								// The ArchiveViewer depends on the number of values being the same and because of different rates for PVs, the bin number for the starting bin could be different...
-								// We could add a firstbin-1 and put all values before the starting timestamp in that bin but that would give incorrect summaries.
-								if(!lastSampleBeforeStartAdded && lastSampleBeforeStart != null) { 
-									switchToNewBin(firstBin-1);
-									currentBinCollector.addEvent(lastSampleBeforeStart);
-									lastSampleBeforeStartAdded = true; 
+							if(eventInstant.isAfter(start) || eventInstant.equals(start)) {
+								if (eventInstant.equals(start)) {
+									shouldAddLastSampleBeforeStart = false;
 								}
-								if(binNumber != currentBin) {
-									if(currentBin != -1) {
-									    SummaryValue summaryValue;
-									    if (vectorType) {
-							                summaryValue = new SummaryValue(((SummaryStatsVectorCollector)currentBinCollector).getVectorValues(), currentMaxSeverity, currentConnectionChangedEvents);
-							            } else {
-    										summaryValue = new SummaryValue(currentBinCollector.getStat(), currentMaxSeverity, currentConnectionChangedEvents);
-    										if(currentBinCollector instanceof SummaryStatsCollectorAdditionalColumns) { 
-    											summaryValue.addAdditionalColumn(((SummaryStatsCollectorAdditionalColumns)currentBinCollector).getAdditionalStats());
-    										}
-							            }
-										consolidatedData.put(currentBin, summaryValue);
-									}
-									switchToNewBin(binNumber);
-								}
-								currentBinCollector.addEvent(e);
-								if(dbrTimeEvent.getSeverity() > currentMaxSeverity) { 
-									currentMaxSeverity = dbrTimeEvent.getSeverity();
-								}
-								if(dbrTimeEvent.hasFieldValues() && dbrTimeEvent.getFields().containsKey("cnxregainedepsecs")) { 
-									currentConnectionChangedEvents = true;
-								}
-							} else if(binNumber < firstBin) { 
-								// Michael Davidsaver's special case; keep track of the last value before the start time and then add that in as a single sample.
-								if(!lastSampleBeforeStartAdded) { 
-									if(lastSampleBeforeStart != null) { 
-										if(e.getEpochSeconds() >= lastSampleBeforeStart.getEpochSeconds()) { 
-											lastSampleBeforeStart = e.makeClone();
+								if (eventInstant.isBefore(end) || eventInstant.equals(end)) {
+									if(binNumber != currentBin) {
+										if(currentBin != -1) {
+											SummaryValue summaryValue;
+											if (vectorType) {
+												summaryValue = new SummaryValue(((SummaryStatsVectorCollector)currentBinCollector).getVectorValues(), currentMaxSeverity, currentConnectionChangedEvents);
+											} else {
+												summaryValue = new SummaryValue(currentBinCollector.getStat(), currentMaxSeverity, currentConnectionChangedEvents);
+												if(currentBinCollector instanceof SummaryStatsCollectorAdditionalColumns) {
+													summaryValue.addAdditionalColumn(((SummaryStatsCollectorAdditionalColumns)currentBinCollector).getAdditionalStats());
+												}
+											}
+											consolidatedData.put(currentBin, summaryValue);
 										}
-									} else { 
-										lastSampleBeforeStart = e.makeClone();
+										switchToNewBin(binNumber);
 									}
+									currentBinCollector.addEvent(e);
+									if(dbrTimeEvent.getSeverity() > currentMaxSeverity) {
+										currentMaxSeverity = dbrTimeEvent.getSeverity();
+									}
+									if(dbrTimeEvent.hasFieldValues() && dbrTimeEvent.getFields().containsKey("cnxregainedepsecs")) {
+										currentConnectionChangedEvents = true;
+									}
+								}
+							} else if (eventInstant.isBefore(start)) {
+								// Michael Davidsaver's special case; keep track of the last value before the start time and then add that in as a single sample.
+								if (lastSampleBeforeStart == null || e.getEventTimeStamp().isAfter(lastSampleBeforeStart.getEventTimeStamp())) {
+									lastSampleBeforeStart = e.makeClone();
 								}
 							}
 						} catch(PBParseException ex) { 
 							logger.error("Skipping possible corrupted event for pv " + strm.getDescription());
 						}
 					}
+
+					// We only add bins for the specified time frame.
+					// The ArchiveViewer depends on the number of values being the same and because of different rates for PVs, the bin number for the starting bin could be different...
+					// We could add a firstbin-1 and put all values before the starting timestamp in that bin but that would give incorrect summaries.
+					if(lastSampleBeforeStart != null && shouldAddLastSampleBeforeStart) {
+						switchToNewBin(firstBin-1);
+						currentBinCollector.addEvent(lastSampleBeforeStart);
+						lastSampleBeforeStartAdded = true;
+					}
+
 					return new SummaryStatsCollectorEventStream(firstBin, lastBin, intervalSecs, srcDesc, consolidatedData, inheritValuesFromPreviousBins, zeroOutEmptyBins(), vectorType, elementCount);
 				}
 			}

--- a/src/test/org/epics/archiverappliance/retrieval/postprocessor/OptimizedPostProcessorTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/postprocessor/OptimizedPostProcessorTest.java
@@ -180,10 +180,11 @@ public class OptimizedPostProcessorTest {
             Instant start = TimeUtils.convertFromYearSecondTimestamp(startOfSamples).plusMillis(millisToAddToStart);
             Instant end = TimeUtils.convertFromYearSecondTimestamp(startOfSamples).plusMillis(millisToAddToEnd);
             optimizedPostProcessor.estimateMemoryConsumption(optimizedTestPVName, new PVTypeInfo(optimizedTestPVName, ArchDBRTypes.DBR_SCALAR_DOUBLE, true, 1), start, end, null);
+            var callableEventStream = CallableEventStream.makeOneStreamCallable(testData, null, false);
             try {
-                optimizedPostProcessor.wrap(CallableEventStream.makeOneStreamCallable(testData, null, false)).call();
+                optimizedPostProcessor.wrap(callableEventStream).call();
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                Assertions.fail("An exception occurred when calling optimizedPostProcessor.wrap(callableEventStream).call()");
             }
 
             List<Event> events = new LinkedList<>();


### PR DESCRIPTION
This PR implements two bug-fixes to `SummaryStatsPostProcessor` and one bug-fix and one improvement to `Optimized`.

The two bug-fixes added to `SummaryStatsPostProcessor` are:
 **1.A** Check the time stamps instead of the bin number when deciding whether a data point should be put in a bin.
 **1.B** Ensure that the last sample before the start of the interval is added, unless the start of the interval coincides with a data-point. (Previously, the last sample would only be added if there existed a data point in the specified interval, but the specified interval may of course be empty.)

The improvements to `Optimized` are:
 **2.A** `intervalSecs` is now bounded below by 1. (Previously, it could assume the value `0`.)
 **2.B** In the computation of `intervalSecs`, the cast `long` -> `int` is now checked for overflow.

Some test cases have been implemented in `OptimizedPostProcessorTest`.

**Question:** I am not sure about point **1.A**: is it correct to only include data points that are strictly within the specified interval? E.g.: Suppose the specified interval is `[0.5, 1.0]` but that the first bin covers the interval `[0.0, 1.0]`. Should then data-points with, e.g., `t=0.4` be added to the first bin? I believe, but I am not sure, that they should not, and that is what the PR implements.